### PR TITLE
Switch from tripleo-ansible to edpm-ansible repo

### DIFF
--- a/ansibleee/Dockerfile
+++ b/ansibleee/Dockerfile
@@ -1,28 +1,28 @@
-FROM quay.io/ansible/ansible-runner:latest
+FROM quay.io/ansible/creator-ee:latest
 USER root
 RUN chmod g=u /etc/passwd /etc/group
-# Install tripleo-ansible content
-# Install packages from tripleo-ansible bindep
-RUN dnf -y install gcc-c++  git libffi-devel openssl-devel podman \
-    python3-devel python3-pyyaml python3-dnf python-rhsm-certificates python3-libselinux python3-libsemanage \
-    gzip gettext && dnf clean all && rm -rf /var/cache/{dnf,yum} && rm -rf /var/lib/dnf/history.* && rm -rf /var/log/*
-RUN /usr/bin/git clone https://github.com/openstack/tripleo-ansible /var/tmp/tripleo-ansible
-RUN cd /var/tmp/tripleo-ansible && pip install -r requirements.txt
+# Install edpm-ansible content
+# Install packages from edpm-ansible bindep
+#RUN dnf -y install gcc-c++  git libffi-devel openssl-devel podman \
+#    python3-devel python3-pyyaml python3-dnf python-rhsm-certificates python3-libselinux python3-libsemanage \
+#    gzip gettext && dnf clean all && rm -rf /var/cache/{dnf,yum} && rm -rf /var/lib/dnf/history.* && rm -rf /var/log/*
+RUN /usr/bin/git clone https://github.com/openstack-k8s-operators/edpm-ansible /var/tmp/edpm-ansible
+RUN cd /var/tmp/edpm-ansible && pip install -r requirements.txt
 # ansible-galaxy issue with PyOpenSSL https://github.com/ansible/awx/issues/12124
 RUN pip3 install 'pyOpenSSL<20.0.0' 'cryptography >35,<37'
-RUN cd /var/tmp/tripleo-ansible && ansible-galaxy role install -r requirements.yml --roles-path "/usr/share/ansible/roles" && \
+RUN cd /var/tmp/edpm-ansible && ansible-galaxy role install -r requirements.yml --roles-path "/usr/share/ansible/roles" && \
     ansible-galaxy collection install -r requirements.yml --collections-path "/usr/share/ansible/collections"
-RUN cd /var/tmp/tripleo-ansible && python3 setup.py install --prefix=/usr
-RUN rm -fr /var/tmp/tripleo-ansible
+RUN cd /var/tmp/edpm-ansible && python3 setup.py install --prefix=/usr
+RUN rm -fr /var/tmp/edpm-ansible
 RUN chmod -R 777 /usr/share/ansible
 COPY settings /runner/env/settings
 RUN chmod 777 /runner/env/settings
-COPY tripleo_entrypoint.sh /bin/tripleo_entrypoint
+COPY edpm_entrypoint.sh /bin/edpm_entrypoint
 RUN sed -i '1d' /bin/entrypoint
-RUN cat /bin/entrypoint >> /bin/tripleo_entrypoint
-RUN chmod +x /bin/tripleo_entrypoint
+RUN cat /bin/entrypoint >> /bin/edpm_entrypoint
+RUN chmod +x /bin/edpm_entrypoint
 WORKDIR /runner
 RUN rm -rf roles && ln -snf /usr/share/ansible/roles roles
-RUN rm -rf project && ln -snf /usr/share/ansible/tripleo-playbooks project
+RUN rm -rf project && ln -snf /usr/share/ansible/edpm-playbooks project
 USER 1001
-ENTRYPOINT ["tripleo_entrypoint"]
+ENTRYPOINT ["edpm_entrypoint"]

--- a/ansibleee/Dockerfile
+++ b/ansibleee/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/creator-ee:latest
+FROM quay.io/ansible/creator-ee:v0.13.0
 USER root
 RUN chmod g=u /etc/passwd /etc/group
 # Install edpm-ansible content

--- a/ansibleee/edpm_entrypoint.sh
+++ b/ansibleee/edpm_entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Adding tripleo ansible-runner specific scripts here
+# Adding edpm ansible-runner specific scripts here
 # Expand the variables
 eval "echo \"$(cat /runner/env/settings)\"" > /runner/env/settings
 

--- a/ansibleee/requirements.yaml
+++ b/ansibleee/requirements.yaml
@@ -14,6 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# Custom Roles and collections not shipped as a part of tripleo-ansible
+# Custom Roles and collections not shipped as a part of edpm-ansible
 collections: []
 roles: []


### PR DESCRIPTION
Changed the repo used within openstack-ansibleee-runner image from tripleo-ansible to edpm-ansible.

Also, the baseimage in the dockerfile was changed from `quay.io/ansible/ansible-runner:latest` to `quay.io/ansible/creator-ee:v0.13.0` because ansible-runner was kinda old (centos stream 8, ansible 2.12). 

creator-ee image maybe isn't the best choice since it's based on Fedora 37, but contains the last version of ansible, 2.14.1, that works well with edpm-ansible.

Could we wait for ansible dev to release an updated version of ansible-runner image (there is an issue opened by @raukadah about that, but there are no updates since November 2022) or we can fork the project and create "our" base image.

In the meanwhile I pushed the resulting openstack-ansibleee-runner image on my quay repo, [here](https://quay.io/repository/ralfieri/openstack-ansibleee-runner), if you want to try it.

Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>