### PR TITLE
Add support for building ee image using local edpm-ansible repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 # openstack-ansibleee-runner image
 EEIMG ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner
 
+# edpm-ansible local repo
+EDPM_LOCAL_REPO ?= ""
+
 VERIFY_TLS ?= true
 
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
@@ -135,7 +138,11 @@ docker-push: ## Push docker image with the manager.
 ##@ Build openstack-ansibleee-runner image
 .PHONY: docker-build-ee
 docker-build-ee:
-	cd ansibleee; podman build -t ${EEIMG} .
+	if [ "$EDPM_LOCAL_REPO" != "" ] ; then \
+		cd ansibleee; podman build -t ${EEIMG} . --volume ${EDPM_LOCAL_REPO}:/var/tmp/edpm-ansible:z --build-arg EDPM_LOCAL_REPO=${EDPM_LOCAL_REPO}; \
+	else \
+		cd ansibleee; podman build -t ${EEIMG} .; \
+	fi
 
 ## Push openstack-ansible-runner image
 .PHONY: docker-push-ee

--- a/ansibleee/Dockerfile
+++ b/ansibleee/Dockerfile
@@ -17,7 +17,7 @@ RUN pip3 install 'pyOpenSSL<20.0.0' 'cryptography >35,<37'
 RUN cd /var/tmp/edpm-ansible && ansible-galaxy role install -r requirements.yml --roles-path "/usr/share/ansible/roles" && \
     ansible-galaxy collection install -r requirements.yml --collections-path "/usr/share/ansible/collections"
 RUN cd /var/tmp/edpm-ansible && python3 setup.py install --prefix=/usr
-# When local repo of edpm-ansible is mounted as a volume, during podman build 
+# When local repo of edpm-ansible is mounted as a volume, during podman build
 # It will give Device/Resource busy. In order to fix that. Clean up the directory
 # Only when EDPM_LOCAL_REPO is defined.
 RUN if [ "$EDPM_LOCAL_REPO" == "" ] ; then \

--- a/ansibleee/Dockerfile
+++ b/ansibleee/Dockerfile
@@ -1,4 +1,5 @@
 FROM quay.io/ansible/creator-ee:v0.13.0
+ARG EDPM_LOCAL_REPO=""
 USER root
 RUN chmod g=u /etc/passwd /etc/group
 # Install edpm-ansible content
@@ -6,14 +7,23 @@ RUN chmod g=u /etc/passwd /etc/group
 #RUN dnf -y install gcc-c++  git libffi-devel openssl-devel podman \
 #    python3-devel python3-pyyaml python3-dnf python-rhsm-certificates python3-libselinux python3-libsemanage \
 #    gzip gettext && dnf clean all && rm -rf /var/cache/{dnf,yum} && rm -rf /var/lib/dnf/history.* && rm -rf /var/log/*
-RUN /usr/bin/git clone https://github.com/openstack-k8s-operators/edpm-ansible.git /var/tmp/edpm-ansible
+RUN if [ ! -d "/var/tmp/edpm-ansible" ] ; then \
+        echo "Clonning from https://github.com/openstack-k8s-operators/edpm-ansible.git"; \
+        /usr/bin/git clone https://github.com/openstack-k8s-operators/edpm-ansible.git /var/tmp/edpm-ansible; \
+    fi
 RUN cd /var/tmp/edpm-ansible && pip install -r requirements.txt
 # ansible-galaxy issue with PyOpenSSL https://github.com/ansible/awx/issues/12124
 RUN pip3 install 'pyOpenSSL<20.0.0' 'cryptography >35,<37'
 RUN cd /var/tmp/edpm-ansible && ansible-galaxy role install -r requirements.yml --roles-path "/usr/share/ansible/roles" && \
     ansible-galaxy collection install -r requirements.yml --collections-path "/usr/share/ansible/collections"
 RUN cd /var/tmp/edpm-ansible && python3 setup.py install --prefix=/usr
-RUN rm -fr /var/tmp/edpm-ansible
+# When local repo of edpm-ansible is mounted as a volume, during podman build 
+# It will give Device/Resource busy. In order to fix that. Clean up the directory
+# Only when EDPM_LOCAL_REPO is defined.
+RUN if [ "$EDPM_LOCAL_REPO" == "" ] ; then \
+        echo $EDPM_LOCAL_REPO; \
+        rm -fr /var/tmp/edpm-ansible; \
+    fi
 RUN chmod -R 777 /usr/share/ansible
 COPY settings /runner/env/settings
 RUN chmod 777 /runner/env/settings


### PR DESCRIPTION
In order to build ee image from local edpm-ansible changes. It adds the support for the same by passing the clone directory as a volume to the build args.

It will be useful in CI jobs where the project is clonned in the job workspace.

Signed-off-by: Chandan Kumar <raukadah@gmail.com>