### PR TITLE
Removing deprecated go-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
       exclude: ^vendor
     - id: go-vet
     - id: go-mod-tidy
-    - id: go-lint
 
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.50.1


### PR DESCRIPTION
The [tool](https://github.com/golang/lint) has been [deprecated](https://github.com/golang/go/issues/38968) since May 2021 as it wasn't maintained for a considerable period of time and is no longer recommended.

We already have golangci-lint which provides similar service. It would be better to drop this tool from our .pre-commit, since we can't be certain of its stability. Not to mention the fact that it may very well become disjointed from future language developments.

Signed-off-by: Jiri Podivin <jpodivin@redhat.com>