### PR TITLE
Change Task Vars to be []string

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1913,7 +1913,9 @@ spec:
                             type: string
                           type: array
                         vars:
-                          type: string
+                          items:
+                            type: string
+                          type: array
                         when:
                           type: string
                       required:

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -139,7 +139,7 @@ type Role struct {
 type Task struct {
 	Name       string     `json:"name"`
 	ImportRole ImportRole `json:"import_role" yaml:"import_role"`
-	Vars       string     `json:"vars,omitempty"`
+	Vars       []string   `json:"vars,omitempty"`
 	When       string     `json:"when,omitempty"`
 	Tags       []string   `json:"tags,omitempty"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -230,6 +230,11 @@ func (in *Role) DeepCopy() *Role {
 func (in *Task) DeepCopyInto(out *Task) {
 	*out = *in
 	out.ImportRole = in.ImportRole
+	if in.Vars != nil {
+		in, out := &in.Vars, &out.Vars
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]string, len(*in))

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1913,7 +1913,9 @@ spec:
                             type: string
                           type: array
                         vars:
-                          type: string
+                          items:
+                            type: string
+                          type: array
                         when:
                           type: string
                       required:

--- a/docs/openstack_ansibleee.md
+++ b/docs/openstack_ansibleee.md
@@ -116,7 +116,7 @@ Task describes a task centered exclusively in running import_role
 | ----- | ----------- | ------ | -------- |
 | name |  | string | true |
 | import_role |  | [ImportRole](#importrole) | true |
-| vars |  | string | false |
+| vars |  | []string | false |
 | when |  | string | false |
 | tags |  | []string | false |
 


### PR DESCRIPTION
When deploying a OpenStackDataPlaneNode, the created openstackansibleee fails with wrong type for vars:

```
Identity added: /runner/artifacts/643f357f-5f77-4284-9a48-79df8d67f89c/ssh_key_data (root@osp-converge-01.lab.eng.brq2.redhat.com) ERROR! Vars in a IncludeRole must be specified as a dictionary, or a list of dictionaries

The error appears to be in '/usr/share/ansible/edpm-playbooks/playbook.yaml': line 13, column 13, but may be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

        tasks_from: main.yml
      vars: ""
            ^ here
```

This changes the Vars in the Task struct to be of type []string.