### PR TITLE
Add support for /runner/env/cmdline

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -48,6 +48,9 @@ spec:
                   retried executions.
                 format: int32
                 type: integer
+              cmdLine:
+                description: CmdLine is the command line passed to ansible-runner
+                type: string
               env:
                 description: Env is a list containing the environment variables to
                   pass to the pod

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -69,6 +69,9 @@ type OpenStackAnsibleEESpec struct {
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
+	// +kubebuilder:validation:Optional
+	// CmdLine is the command line passed to ansible-runner
+	CmdLine string `json:"cmdLine,omitempty"`
 }
 
 // OpenStackAnsibleEEStatus defines the observed state of OpenStackAnsibleEE

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -48,6 +48,9 @@ spec:
                   retried executions.
                 format: int32
                 type: integer
+              cmdLine:
+                description: CmdLine is the command line passed to ansible-runner
+                type: string
               env:
                 description: Env is a list containing the environment variables to
                   pass to the pod

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -225,6 +225,9 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(instance *redhat
 	} else {
 		addRoles(instance, h, job)
 	}
+	if len(instance.Spec.CmdLine) > 0 {
+		addCmdLine(instance, job)
+	}
 	addMounts(instance, job)
 
 	// Set OpenStackAnsibleEE instance as the owner and controller
@@ -289,6 +292,14 @@ func addInventory(instance *redhatcomv1alpha1.OpenStackAnsibleEE, job *batchv1.J
 	invEnvVar.Name = "RUNNER_INVENTORY"
 	invEnvVar.Value = "\n" + instance.Spec.Inventory + "\n\n"
 	instance.Spec.Env = append(instance.Spec.Env, invEnvVar)
+	job.Spec.Template.Spec.Containers[0].Env = instance.Spec.Env
+}
+
+func addCmdLine(instance *redhatcomv1alpha1.OpenStackAnsibleEE, job *batchv1.Job) {
+	var cmdLineEnvVar corev1.EnvVar
+	cmdLineEnvVar.Name = "RUNNER_CMDLINE"
+	cmdLineEnvVar.Value = "\n" + instance.Spec.CmdLine + "\n\n"
+	instance.Spec.Env = append(instance.Spec.Env, cmdLineEnvVar)
 	job.Spec.Template.Spec.Containers[0].Env = instance.Spec.Env
 }
 

--- a/docs/openstack_ansibleee.md
+++ b/docs/openstack_ansibleee.md
@@ -78,6 +78,7 @@ OpenStackAnsibleEESpec defines the desired state of OpenStackAnsibleEE
 | ttlSecondsAfterFinished | TTLSecondsAfterFinished specified the number of seconds the job will be kept in Kubernetes after completion. | *int32 | false |
 | roles | Role is the description of an Ansible Role If both Play and Role are specified, Play takes precedence | [Role](#role) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network | []string | false |
+| cmdLine | CmdLine is the command line passed to ansible-runner | string | false |
 
 [Back to Custom Resources](#custom-resources)
 


### PR DESCRIPTION
Sets the $RUNNER_CMDLINE env var with the value of instance.Spec.CmdLine
so that the value is written to /runner/env/cmdline. edpm_entrypoint.sh
in edpm-ansible is responsible for writing the value.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/58
Signed-off-by: James Slagle <jslagle@redhat.com>
