### PR TITLE
allow AEE cr to be created specifying a playbook name

### DIFF
--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -65,7 +65,8 @@ type OpenStackAnsibleEESpec struct {
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 	// Role is the description of an Ansible Role
 	// If both Play and Role are specified, Play takes precedence
-	Role Role `json:"roles,omitempty"`
+	// +kubebuilder:validation:Optional
+	Role *Role `json:"roles,omitempty"`
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -149,7 +149,11 @@ func (in *OpenStackAnsibleEESpec) DeepCopyInto(out *OpenStackAnsibleEESpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	in.Role.DeepCopyInto(&out.Role)
+	if in.Role != nil {
+		in, out := &in.Role, &out.Role
+		*out = new(Role)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NetworkAttachments != nil {
 		in, out := &in.NetworkAttachments, &out.NetworkAttachments
 		*out = make([]string, len(*in))

--- a/docs/openstack_ansibleee.md
+++ b/docs/openstack_ansibleee.md
@@ -76,7 +76,7 @@ OpenStackAnsibleEESpec defines the desired state of OpenStackAnsibleEE
 | extraMounts | ExtraMounts containing conf files and credentials | []storage.VolMounts | false |
 | backoffLimit | BackoffLimimt allows to define the maximum number of retried executions. | *int32 | false |
 | ttlSecondsAfterFinished | TTLSecondsAfterFinished specified the number of seconds the job will be kept in Kubernetes after completion. | *int32 | false |
-| roles | Role is the description of an Ansible Role If both Play and Role are specified, Play takes precedence | [Role](#role) | false |
+| roles | Role is the description of an Ansible Role If both Play and Role are specified, Play takes precedence | *[Role](#role) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network | []string | false |
 | cmdLine | CmdLine is the command line passed to ansible-runner | string | false |
 


### PR DESCRIPTION
This change fixes two bugs. first the roles paremater is made
optional and converted to a pointer so we can test if its defined.
This enables you to create a AEE cr using the golan types
without specifying a role or inline play.

This also fixes the fact that a job does not have a
redhatcomv1alpha1.AnsibleExecutionJobReadyCondition
at least when its complete.

so we just check if it succeded or failed instead.

Closes: #104
