### PR TITLE
Make Tasks optional

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1934,8 +1934,6 @@ spec:
                       - name
                       type: object
                     type: array
-                required:
-                - tasks
                 type: object
               ttlSecondsAfterFinished:
                 default: 86400

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -154,7 +154,7 @@ type Role struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	// gather_facts defaults to false
 	GatherFacts bool   `json:"gather_facts,omitempty" yaml:"gather_facts,omitempty"`
-	Tasks       []Task `json:"tasks"`
+	Tasks       []Task `json:"tasks,omitempty"`
 }
 
 // Task describes a task centered exclusively in running import_role

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1934,8 +1934,6 @@ spec:
                       - name
                       type: object
                     type: array
-                required:
-                - tasks
                 type: object
               ttlSecondsAfterFinished:
                 default: 86400

--- a/docs/openstack_ansibleee.md
+++ b/docs/openstack_ansibleee.md
@@ -106,7 +106,7 @@ Role describes the format of an ansible playbook destinated to run roles
 | any_errors_fatal | any_errors_fatal defaults to true | bool | false |
 | become | become defaults to false | bool | false |
 | gather_facts | gather_facts defaults to false | bool | false |
-| tasks |  | [][Task](#task) | true |
+| tasks |  | [][Task](#task) | false |
 
 [Back to Custom Resources](#custom-resources)
 


### PR DESCRIPTION
Marks Tasks as omitempty, that way they do not have to be set. Without
this change, it is not possible to use just Spec.Play without Spec.Role
when creating an OpenStackAnsibleEE instance.

Signed-off-by: James Slagle <jslagle@redhat.com>
