### PR TITLE
Default strategy to linear

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1898,8 +1898,8 @@ spec:
                     default: Run Standalone Role
                     type: string
                   strategy:
-                    default: free
-                    description: strategy defaults to free
+                    default: linear
+                    description: strategy defaults to linear
                     type: string
                   tasks:
                     items:

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -139,8 +139,8 @@ type Role struct {
 	Name string `json:"name,omitempty"`
 	// +kubebuilder:default:="{{ primary_role_name | default([]) }}:{{ deploy_target_host | default('overcloud') }}"
 	Hosts string `json:"hosts,omitempty"`
-	// +kubebuilder:default:=free
-	// strategy defaults to free
+	// +kubebuilder:default:=linear
+	// strategy defaults to linear
 	Strategy string `json:"strategy,omitempty"`
 	// +kubebuilder:default:=true
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1898,8 +1898,8 @@ spec:
                     default: Run Standalone Role
                     type: string
                   strategy:
-                    default: free
-                    description: strategy defaults to free
+                    default: linear
+                    description: strategy defaults to linear
                     type: string
                   tasks:
                     items:

--- a/docs/openstack_ansibleee.md
+++ b/docs/openstack_ansibleee.md
@@ -102,7 +102,7 @@ Role describes the format of an ansible playbook destinated to run roles
 | ----- | ----------- | ------ | -------- |
 | name |  | string | false |
 | hosts |  | string | false |
-| strategy | strategy defaults to free | string | false |
+| strategy | strategy defaults to linear | string | false |
 | any_errors_fatal | any_errors_fatal defaults to true | bool | false |
 | become | become defaults to false | bool | false |
 | gather_facts | gather_facts defaults to false | bool | false |


### PR DESCRIPTION
Changes the ansible strategy default from free to linear. Using free was
an optimization for TripleO that is not necessary with edpm-ansible.

Signed-off-by: James Slagle <jslagle@redhat.com>
