### PR TITLE
Let ansible playbooks to be executed with ansible user spawning pods via custom service account

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,3 +3,53 @@ kind: ServiceAccount
 metadata:
   name: controller-manager
   namespace: system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ansibleee
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ansibleee-role
+  namespace: openstack
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - post
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ansibleee-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ansibleee-role
+subjects:
+# Applying the role to both SA (with and without prefix) to be able
+# to run the operator local
+- kind: ServiceAccount
+  name: ansibleee-operator-ansibleee
+  namespace: openstack
+- kind: ServiceAccount
+  name: ansibleee
+  namespace: openstack

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -7,12 +7,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ansibleee
+  name: openstack-ansibleee
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ansibleee-role
+  name: openstack-ansibleee-role
   namespace: openstack
 rules:
 - apiGroups:
@@ -39,11 +39,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ansibleee-rolebinding
+  name: openstack-ansibleee-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ansibleee-role
+  name: openstack-ansibleee-role
 subjects:
 # Applying the role to both SA (with and without prefix) to be able
 # to run the operator local

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -7,12 +7,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openstack-ansibleee
+  name: ansibleee
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: openstack-ansibleee-role
+  name: ansibleee-role
   namespace: openstack
 rules:
 - apiGroups:
@@ -39,11 +39,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: openstack-ansibleee-rolebinding
+  name: ansibleee-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: openstack-ansibleee-role
+  name: ansibleee-role
 subjects:
 # Applying the role to both SA (with and without prefix) to be able
 # to run the operator local

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -48,8 +48,8 @@ subjects:
 # Applying the role to both SA (with and without prefix) to be able
 # to run the operator local
 - kind: ServiceAccount
-  name: ansibleee-operator-ansibleee
+  name: openstack-ansibleee-operator-ansibleee
   namespace: openstack
 - kind: ServiceAccount
-  name: ansibleee
+  name: openstack-ansibleee
   namespace: openstack

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -274,7 +274,7 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(instance *redhat
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicy(instance.Spec.RestartPolicy),
-					ServiceAccountName: "openstack-ansibleee-operator-ansibleee",
+					ServiceAccountName: "openstack-ansibleee-operator-openstack-ansibleee",
 					Containers: []corev1.Container{{
 						ImagePullPolicy: "Always",
 						Image:           instance.Spec.Image,

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -274,7 +274,7 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(instance *redhat
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicy(instance.Spec.RestartPolicy),
-					ServiceAccountName: "openstack-ansibleee-operator-openstack-ansibleee",
+					ServiceAccountName: "openstack-ansibleee-operator-ansibleee",
 					Containers: []corev1.Container{{
 						ImagePullPolicy: "Always",
 						Image:           instance.Spec.Image,

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -273,7 +273,8 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(instance *redhat
 					Labels:      ls,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicy(instance.Spec.RestartPolicy),
+					RestartPolicy:      corev1.RestartPolicy(instance.Spec.RestartPolicy),
+					ServiceAccountName: "ansibleee-operator-ansibleee",
 					Containers: []corev1.Container{{
 						ImagePullPolicy: "Always",
 						Image:           instance.Spec.Image,

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -274,7 +274,7 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(instance *redhat
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicy(instance.Spec.RestartPolicy),
-					ServiceAccountName: "ansibleee-operator-ansibleee",
+					ServiceAccountName: "openstack-ansibleee-operator-ansibleee",
 					Containers: []corev1.Container{{
 						ImagePullPolicy: "Always",
 						Image:           instance.Spec.Image,


### PR DESCRIPTION
To avoid "aggressive" permissions on openstack-ansibleee-runner containers (recursive `777` on several folders, including system folders like /usr/share/ansible) we should execute jobs (and their pods) with a service account who has the 'anyuid' SCC.

This PR is a blocker for [#51](https://github.com/openstack-k8s-operators/edpm-ansible/pull/51) in edpm-ansible repo.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/51