### PR TITLE
Fix the wrong task name

### DIFF
--- a/examples/openstack-ansibleee-role.yaml
+++ b/examples/openstack-ansibleee-role.yaml
@@ -15,7 +15,7 @@ spec:
       - name: Generic standalone playbook running tasks
         import_role:
           name: edpm_podman
-          tasks_from: tripleo_podman_configure.yml
+          tasks_from: configure.yml
         tags:
           - edpm_podman
       - name: Generic standalone playbook running tasks


### PR DESCRIPTION
The task file `tripleo_podman_configure.yml` does not exist in the edpm_podman role.