### PR TITLE
Add basic kuttl tests to openstack-ansibleee-operator

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,25 @@
+#
+# EXECUTION (from install_yamls repo root):
+#
+#   make openstack_ansibleee_kuttl
+#
+# ASSUMPTIONS:
+#
+# 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - chmod 755 /usr/local/bin/kubectl-kuttl
+# 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
+# 3. CLI user has access to $KUBECONFIG
+# 4. The environment variable INSTALL_YAMLS is set to the the path of the
+#    install_yamls repo
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-test-openstack-ansibleee
+namespace: openstack
+timeout: 180
+parallel: 1
+suppress:
+  - events                     # Remove spammy event logs

--- a/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
@@ -1,0 +1,62 @@
+#
+# Check for:
+#
+# - 1 OpenStackAnsibleEE CR
+# - 1 Ansibleee-play pod
+# - 1 Ansibleee-play job
+# - Correct output from ansible play
+#
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  name: ansibleee-play
+  namespace: openstack
+spec:
+  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+  name: openstackansibleee
+  play: |
+    - name: Print hello world
+      hosts: localhost
+      tasks:
+      - name: Using debug statement
+        ansible.builtin.debug:
+          msg: "Hello, world this is ansibleee-play.yaml"
+status:
+  JobStatus: Succeeded
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: ansibleee-play-
+  labels:
+    app: openstackansibleee
+    job-name: ansibleee-play
+  namespace: openstack
+status:
+  phase: Succeeded
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: openstackansibleee
+    job-name: ansibleee-play
+  name: ansibleee-play
+  namespace: openstack
+status:
+  ready: 0
+  succeeded: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      pod=$(oc get pods -n openstack -l app=openstackansibleee -o name)
+      logs=$(oc logs -n openstack "$pod" | grep 'Hello, world this is ansibleee-play.yaml')
+
+      if [ -n "$logs" ]; then
+        exit 0
+      else
+        exit 1
+      fi

--- a/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
@@ -1,0 +1,14 @@
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  name: ansibleee-play
+  namespace: openstack
+spec:
+  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+  play: |
+    - name: Print hello world
+      hosts: localhost
+      tasks:
+      - name: Using debug statement
+        ansible.builtin.debug:
+          msg: "Hello, world this is ansibleee-play.yaml"

--- a/tests/kuttl/tests/run_simple_playbook/02-cleanup.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/02-cleanup.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: ansibleee.openstack.org/v1alpha1
+  kind: OpenStackAnsibleEE
+  name: ansibleee-play

--- a/tests/kuttl/tests/run_simple_playbook/02-errors.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/02-errors.yaml
@@ -1,0 +1,23 @@
+#
+# Check for:
+#
+# - No Ansibleee-play pod
+# - No Ansibleee-play job
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: ansible-play-
+  labels:
+    app: openstackansibleee
+    job-name: ansibleee-play
+  namespace: openstack
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: openstackansibleee
+    job-name: ansibleee-play
+  name: ansibleee-play
+  namespace: openstack


### PR DESCRIPTION
Add some simple kuttl test that deploys an operator-ansibleee-operator
CR, a pod and a job to run a simple hello world ansible task. The
second step of the test is to delete the CR and check that resources
created are deleted properly.

Test are thought to be run from the install_yamls repo, see the following PR: openstack-k8s-operators/install_yamls#169

There are three ways to run the tests:

1. Run make `ansibleee_kuttl`, this will only work if you want to run the test from the master branch.
2. Run make `ansibleee_kuttl ANSIBLEEE_REPO=ansibleee-operator/repo_url ANSIBLEEE_BRANCH=branch_name` this is useful if you want to run the tests from a fork
3. Run make `ansibleee_kuttl ANSIBLEEE_KUTTL_CONF=/path/to/ansibleee-operator/kuttl-test.yaml ANSIBLEEE_KUTTL_DIR=/path/to/ansibleee-operator/tests/kuttl/tests/` this is useful to run local changes to the tests
