### PR TITLE
Adjust kuttl assert failing in CI

### DIFF
--- a/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
@@ -44,7 +44,6 @@ metadata:
   name: ansibleee-play
   namespace: openstack
 status:
-  ready: 0
   succeeded: 1
 ---
 apiVersion: kuttl.dev/v1beta1


### PR DESCRIPTION
The assert was passing in CRC, but failing in CI, due to the "ready"
attribute for the Job.
