### PR TITLE
[renovate] run go mod tidy on both mod files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,14 @@ gowork: ## Generate go.work file to support our multi module repository
 	go work use ./api
 	go work sync
 
+APIPATH ?= $(shell pwd)/api
+.PHONY: tidy
+tidy: fmt
+	go mod tidy; \
+	pushd $(APIPATH); \
+	go mod tidy; \
+	popd
+
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
 	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@latest

--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["make gowork", "go mod tidy", "make manifests generate"],
+    "commands": ["make gowork", "make tidy", "make manifests generate"],
     "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }


### PR DESCRIPTION
Renovate only run `go mod tidy` in the root of the repo and that does not update api/go.mod file. So renovate switched to run make tidy that will run go mod tidy on both mod files in the repo.