### PR TITLE
Add revive to golanci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errorlint
+    - revive
+    - gofmt
+    - govet
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,15 +23,13 @@ repos:
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1
   hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
     - id: go-mod-tidy
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.50.1
+  rev: v1.52.2
   hooks:
     - id: golangci-lint
+      args: ["-v"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0

--- a/Makefile
+++ b/Makefile
@@ -338,13 +338,10 @@ gowork: ## Generate go.work file to support our multi module repository
 	go work use ./api
 	go work sync
 
-APIPATH ?= $(shell pwd)/api
 .PHONY: tidy
-tidy: fmt
-	go mod tidy; \
-	pushd $(APIPATH); \
-	go mod tidy; \
-	popd
+tidy: ## Run go mod tidy on every mod file in the repo
+	go mod tidy
+	cd ./api && go mod tidy
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint


### PR DESCRIPTION
This PR replace deprecated go-linter using
revive (https://golangci-lint.run/usage/linters/#revive).

We will add "ginkgolinter" in follow up patch once we merged add pre-commit job in openshift/releases.

If we add "ginkgolinter" in this patch then it's causes below issue [1]

```
level=info msg="[config_reader] Config search paths: [./ /home/prow/go/src/github.com/openstack-k8s-operators/dataplane-operator /home/prow/go/src/github.com/openstack-k8s-operators /home/prow/go/src/github.com /home/prow/go/src /home/prow/go /home/prow /home /]"
level=info msg="[config_reader] Used config file .golangci.yaml"
level=error msg="Running error: unknown linters: 'ginkgolinter', run 'golangci-lint help linters' to see the list of supported linters"
```

This patch also Remove fmt dependency from make tidy as per [2]:

The fmt dependency cannot be run if the go.mod file needs an update:
```
 $ make tidy
 go fmt ./...
 go: updates to go.mod needed; to update it:
        go mod tidy
 make: *** [Makefile:103: fmt] Error 1
```

I have also made some changes as per the comment given here [3]

[1]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openstack-k8s-operators_dataplane-operator/147/pull-ci-openstack-k8s-operators-dataplane-operator-main-golangci/1643555465537261568/artifacts/test/build-log.txt 
[2]: https://github.com/openstack-k8s-operators/placement-operator/pull/153
[3]: https://github.com/openstack-k8s-operators/cinder-operator/pull/147#discussion_r1158504341