### PR TITLE
Add ANSIBLE_RUNNER_DEBUG_CMD

### DIFF
--- a/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
@@ -44,13 +44,6 @@ spec:
         path: roles.gather_facts
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: 'TTLSecondsAfterFinished specified the number of seconds the
-          job will be kept in Kubernetes after completion. TTLSecondsAfterFinished
-          default: 86400'
-        displayName: TTLSeconds After Finished
-        path: ttlSecondsAfterFinished
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
       statusDescriptors:
       - description: Conditions
         displayName: Conditions

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -94,11 +95,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	ansibleRunnerDebugCommand := strings.Split(os.Getenv("ANSIBLE_RUNNER_DEBUG_CMD"), " ")
 	if err = (&controllers.OpenStackAnsibleEEReconciler{
-		Client:  mgr.GetClient(),
-		Scheme:  mgr.GetScheme(),
-		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackAnsibleEE"),
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Kclient:               kclient,
+		AnsibleRunnerDebugCmd: ansibleRunnerDebugCommand,
+		Log:                   ctrl.Log.WithName("controllers").WithName("OpenStackAnsibleEE"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackAnsibleEE")
 		os.Exit(1)


### PR DESCRIPTION
Setting this env will allow the administrator to override the default ansible command to use with arbitrary ansible job commands. Potentially useful for mocked out testing for scale...