### PR TITLE
Fix RUNNER_PLAYBOOK when role isn't empty

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -293,10 +293,12 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(instance *redhat
 	}
 	if len(instance.Spec.Play) > 0 {
 		addPlay(instance, job)
-	} else if len(instance.Spec.Playbook) > 0 {
-		addPlaybook(instance, job)
 	} else if instance.Spec.Role != nil {
 		addRoles(instance, h, job)
+	} else if len(instance.Spec.Playbook) > 0 {
+		// As we set "playbook.yaml" as default
+		// we need to ensure that Play and Role are empty before addPlaybook
+		addPlaybook(instance, job)
 	}
 	if len(instance.Spec.CmdLine) > 0 {
 		addCmdLine(instance, job)


### PR DESCRIPTION
we currently set "playbook.yaml"  as default, therefore we need to set playbook env after checking if play or role are empty