### PR TITLE
Document log persistence 

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/storage/names"
 
 	"context"
 
@@ -254,6 +255,21 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(instance *redhat
 			instance.Spec.Playbook = "playbook.yaml"
 		}
 		args = []string{"ansible-runner", "run", "/runner", "-p", instance.Spec.Playbook}
+	}
+
+	hasIdentifier := false
+	for _, arg := range args {
+		// ansible runner identifier
+		// https://ansible-runner.readthedocs.io/en/stable/intro/#artifactdir
+		if arg == "-i" || arg == "--ident" {
+			hasIdentifier = true
+			break
+		}
+	}
+
+	if !hasIdentifier {
+		identifier := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", instance.Name))
+		args = append(args, []string{"-i", identifier}...)
 	}
 
 	job := &batchv1.Job{

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,28 @@
+# Persistent logs
+
+For enabling persistent logging, you need to mount `/runner/artifacts` into a [persistent Volume](https://kubernetes.io/docs/concepts/storage/volumes/) through `extraMounts` field.
+
+#### Example:
+```yaml
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  name: ansibleee-logs
+  namespace: openstack
+spec:
+  playbook: "test.yaml"
+  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+  inventory: |
+          all:
+            hosts:
+              localhost
+  extraMounts:
+    - extraVolType: Logs
+      volumes:
+      - name: ansible-logs
+        persistentVolumeClaim:
+          claimName: openstack-ansible-logs
+      mounts:
+      - name: ansible-logs
+        mountPath: "/runner/artifacts"
+```

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
+	k8s.io/apiserver v0.26.2
 	k8s.io/client-go v0.26.3
 	sigs.k8s.io/controller-runtime v0.14.6
 )

--- a/go.sum
+++ b/go.sum
@@ -639,6 +639,8 @@ k8s.io/apiextensions-apiserver v0.26.2 h1:/yTG2B9jGY2Q70iGskMf41qTLhL9XeNN2KhI0u
 k8s.io/apiextensions-apiserver v0.26.2/go.mod h1:Y7UPgch8nph8mGCuVk0SK83LnS8Esf3n6fUBgew8SH8=
 k8s.io/apimachinery v0.26.3 h1:dQx6PNETJ7nODU3XPtrwkfuubs6w7sX0M8n61zHIV/k=
 k8s.io/apimachinery v0.26.3/go.mod h1:ats7nN1LExKHvJ9TmwootT00Yz05MuYqPXEXaVeOy5I=
+k8s.io/apiserver v0.26.2 h1:Pk8lmX4G14hYqJd1poHGC08G03nIHVqdJMR0SD3IH3o=
+k8s.io/apiserver v0.26.2/go.mod h1:GHcozwXgXsPuOJ28EnQ/jXEM9QeG6HT22YxSNmpYNh8=
 k8s.io/client-go v0.26.3 h1:k1UY+KXfkxV2ScEL3gilKcF7761xkYsSD6BC9szIu8s=
 k8s.io/client-go v0.26.3/go.mod h1:ZPNu9lm8/dbRIPAgteN30RSXea6vrCpFvq+MateTUuQ=
 k8s.io/component-base v0.26.2 h1:IfWgCGUDzrD6wLLgXEstJKYZKAFS2kO+rBRi0p3LqcI=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,8 @@ nav:
   - Home: index.md
   - Custom Resources:
       - OpenStackAnsibleEE: openstack_ansibleee.md
+  - Config:
+    - Logs: logs.md
   - Contributing: contributing.md
 markdown_extensions:
   - toc:


### PR DESCRIPTION
ansible runner store the logs into `artifacts/*/stdout`:
```
[dpadev@osp-dev-05 director_standalone]$ oc exec -it dataplane-deployment-configure-network-edpmadoption-kmnrt -- bash
1000670000@creator-ee:v0.14.1: /runner 
$ ls
artifacts  env	inventory  network  project
1000670000@creator-ee:v0.14.1: /runner 
$ ls artifacts/
4256577f-6774-41ae-bfad-bb65cfe5028b
1000670000@creator-ee:v0.14.1: /runner 
$ ls artifacts/4256577f-6774-41ae-bfad-bb65cfe5028b/
1000670000@creator-ee:v0.14.1: /runner 
$ cat artifacts/4256577f-6774-41ae-bfad-bb65cfe5028b/stdout 
Identity added: /runner/artifacts/4256577f-6774-41ae-bfad-bb65cfe5028b/ssh_key_data (/runner/artifacts/4256577f-6774-41ae-bfad-bb65cfe5028b/ssh_key_data)
[WARNING]: log file at /var/log/ansible.log is not writeable and we cannot create it, aborting

ansible-playbook [core 2.14.1]
  config file = None
  configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.11/site-packages/ansible
  ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.11.1 (main, Jan  6 2023, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
No config file found; using defaults
statically imported: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_bootstrap/tasks/packages.yml
redirecting (type: modules) ansible.builtin.selinux to ansible.posix.selinux
statically imported: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_kernel/tasks/hugepages_parsing.yaml
statically imported: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_kernel/tasks/hugepages_validations.yaml
redirecting (type: modules) ansible.builtin.sefcontext to community.general.sefcontext
Skipping callback 'awx_display', as we already have a stdout callback.
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: playbook.yaml ********************************************************
1 plays in playbook.yaml

PLAY [Deploy EDPM Network] *****************************************************

TASK [Gathering Facts] *********************************************************
task path: /runner/project/playbook.yaml:3
fatal: [standalone]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Warning: Permanently added '192.168.121.87' (ED25519) to the list of known hosts.\r\nroot@192.168.121.87: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).", "unreachable": true}
```
https://ansible-runner.readthedocs.io/en/stable/intro/#artifactdir

This PR sets an identifier for the ansible-runner artifacts and documents how to persist the logs