### PR TITLE
Added EDPM based Zuul jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,6 @@ EEIMG ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner
 # edpm-ansible local repo
 EDPM_LOCAL_REPO ?= ""
 
-VERIFY_TLS ?= true
-
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
@@ -136,7 +134,7 @@ docker-build: test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	podman push --tls-verify=${VERIFY_TLS} ${IMG}
+	podman push ${IMG}
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
@@ -167,7 +165,7 @@ docker-build-ee:
 ## Push openstack-ansible-runner image
 .PHONY: docker-push-ee
 docker-push-ee:
-	cd ansibleee; podman push --tls-verify=${VERIFY_TLS} ${EEIMG}
+	cd ansibleee; podman push ${EEIMG}
 
 ##@ Deployment
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,18 @@
+---
+- job:
+    name: ansibleee-operator-content-provider
+    parent: content-provider-base
+    vars:
+      cifmw_operator_build_org: openstack-k8s-operators
+      cifmw_operator_build_operators:
+        - name: "openstack-ansibleee-operator"
+          src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/openstack-ansibleee-operator"
+        - name: "openstack-operator"
+          src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+          image_base: ansibleee
+
+- job:
+    name: ansibleee-operator-crc-podified-edpm-deployment
+    parent: cifmw-crc-podified-edpm-deployment
+    vars:
+      bmo_setup: true

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,9 @@
+---
+- project:
+    name: openstack-k8s-operators/openstack-ansibleee-operator
+    github-check:
+      jobs:
+        - ansibleee-operator-content-provider
+        - ansibleee-operator-crc-podified-edpm-deployment:
+            dependencies:
+              - ansibleee-operator-content-provider


### PR DESCRIPTION
It adds following jobs which will run against dataplane operator.:

- ansibleee-operator-content-provider job which will build the operator and meta operator images and push it to local registry. The job will be paused to serve as a registry.
- ansibleee-operator-crc-podified-edpm-deployment is the child job which will pull the required meta operator images from content provider. The Zuul will pass the necessary vars to the child job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/171
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/312