### PR TITLE
Fix controller manager labeling

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -14,10 +14,11 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: openstack-ansibleee-operator
     app.kubernetes.io/component: ansibleee
+    openstack.org/operator-name: ansibleee
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: ansibleee
   replicas: 1
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
         control-plane: controller-manager
         app.kubernetes.io/name: openstack-ansibleee-operator
         app.kubernetes.io/component: ansibleee
+        openstack.org/operator-name: ansibleee
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: ansibleee

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    openstack.org/operator-name: ansibleee


### PR DESCRIPTION
We now have a final form for operator controller-manager pod labeling of the format `openstack.org/operator-name: <operator name>` and are no longer relying on the inconsistent labels created by various `operator-sdk` versions.  All operators that lack this standardized pattern are being updated.