### PR TITLE
Add env from configmap

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -119,6 +119,9 @@ spec:
                   - name
                   type: object
                 type: array
+              envConfigMapName:
+                default: openstack-aee-default-env
+                type: string
               extraMounts:
                 items:
                   properties:

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -48,6 +48,9 @@ type OpenStackAnsibleEESpec struct {
 	// Name is the name of the internal container inside the pod
 	// +kubebuilder:default:="openstackansibleee"
 	Name string `json:"name,omitempty"`
+	// EnvConfigMapName is the name of the k8s config map that contains the ansible env variables
+	// +kubebuilder:default:="openstack-aee-default-env"
+	EnvConfigMapName string `json:"envConfigMapName,omitempty"`
 	// Env is a list containing the environment variables to pass to the pod
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// RestartPolicy is the policy applied to the Job on whether it needs to restart the Pod. It can be "OnFailure" or "Never".

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -119,6 +119,9 @@ spec:
                   - name
                   type: object
                 type: array
+              envConfigMapName:
+                default: openstack-aee-default-env
+                type: string
               extraMounts:
                 items:
                   properties:

--- a/docs/openstack_ansibleee.md
+++ b/docs/openstack_ansibleee.md
@@ -69,6 +69,7 @@ OpenStackAnsibleEESpec defines the desired state of OpenStackAnsibleEE
 | image | Image is the container image that will execute the ansible command | string | false |
 | args | Args are the command plus the playbook executed by the image. If args is passed, Playbook is ignored. | []string | false |
 | name | Name is the name of the internal container inside the pod | string | false |
+| envConfigMapName | EnvConfigMapName is the name of the k8s config map that contains the ansible env variables | string | false |
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 | restartPolicy | RestartPolicy is the policy applied to the Job on whether it needs to restart the Pod. It can be \"OnFailure\" or \"Never\". RestartPolicy default: Never | string | false |
 | uid | UID is the userid that will be used to run the container. | int64 | false |


### PR DESCRIPTION
Given a configmap with the name "openstack-aee-default-env",  AEE will get the env variables from this and sets it on the Job.envFrom. When a variable is set on both configmap and AEE.Env, the AEE.Env will prevail

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/211
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/212