### PR TITLE
Create constants to define JobStatus

### DIFF
--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -31,6 +31,20 @@ const (
 	OpenStackAnsibleEEContainerImage = "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
 )
 
+const (
+	// JobStatusSucceeded -
+	JobStatusSucceeded = "Succeeded"
+
+	// JobStatusFailed -
+	JobStatusFailed = "Failed"
+
+	// JobStatusRunning -
+	JobStatusRunning = "Running"
+
+	// JobStatusPending -
+	JobStatusPending = "Pending"
+)
+
 // OpenStackAnsibleEESpec defines the desired state of OpenStackAnsibleEE
 type OpenStackAnsibleEESpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster


### PR DESCRIPTION
... so that we can use these constants in the logics using AnsibleEE types. Also, this ensures JobStatus is initialized with the Pending status, which is not currently used.