### PR TITLE
Remove unnecessary initialization of JobStatus

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -140,11 +140,6 @@ func (r *OpenStackAnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.R
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}
 
-	// Initialize Job Status field
-	if instance.Status.JobStatus == "" {
-		instance.Status.JobStatus = redhatcomv1alpha1.JobStatusPending
-	}
-
 	// networks to attach to
 	for _, netAtt := range instance.Spec.NetworkAttachments {
 		_, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)


### PR DESCRIPTION
The JobStatus field defaults to "Pending" as is defined by SDK Macro. Thus initializing this value in controller is not required.