### PR TITLE
Adding debug target for the image build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG GOLANG_BUILDER=golang:1.19
-ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG OPERATOR_BASE_IMAGE_TAG=nonroot
+ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:${OPERATOR_BASE_IMAGE_TAG}
 
 # Build the manager binary
 FROM $GOLANG_BUILDER AS builder


### PR DESCRIPTION
Standard operator base image has barely any utilities available, this makes sense as we don't really need any of them. However, this also means we can't ssh into it and we can't inspect it in detail if standard debugging fails.

This PR adjusts the build procedure, so that if requested and alternate image, with integrated busybox binary, is pulled.
The newly created operator image is tagged with a `-debug` suffix, to ensure it's not pulled by accident. 

The `OPERATOR_BASE_IMAGE_TAG` can be used to optionally parametrize pulled base image. 

Note that caution should be exercised while reviewing this PR, as it concerns low level workings of the operator.
It is possible, or even likely, that the debug image will exhibit undesirable performance characteristics, as it has to deal with extra utilities. For the same reason it will require slightly more storage.

Furthermore, it is important to realize that while the debug image will have more utilities available, it is still not, and should not be, a full fledged environment. Because Busybox implements only the most basic of tools. 

[0] https://console.cloud.google.com/gcr/images/distroless/GLOBAL/static:nonroot/details?pli=1

[1] https://github.com/GoogleContainerTools/distroless/tree/main 