### PR TITLE
Switch the value of `PreserveJobs` to `true`

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1508,7 +1508,7 @@ spec:
               playbook:
                 type: string
               preserveJobs:
-                default: false
+                default: true
                 type: boolean
               restartPolicy:
                 default: Never

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -74,7 +74,7 @@ type OpenStackAnsibleEESpec struct {
 	// +kubebuilder:default:="Never"
 	RestartPolicy string `json:"restartPolicy,omitempty"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
+	// +kubebuilder:default=true
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
 	PreserveJobs bool `json:"preserveJobs"`
 	// UID is the userid that will be used to run the container.

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1508,7 +1508,7 @@ spec:
               playbook:
                 type: string
               preserveJobs:
-                default: false
+                default: true
                 type: boolean
               restartPolicy:
                 default: Never


### PR DESCRIPTION
To avoid losing logs of ansibleee executions, let's set `PreserveJobs` property to `true`, so the jobs won't be deleted after 10 minutes.

This patch is a followup of https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/pull/126 which didn't solve the issue reported in the commit message.


See the function `defaultTTL` in lib-common/common/job/job.go [code](https://github.com/openstack-k8s-operators/lib-common/blob/cd98c8b8631059c13812fce680b0005d520e4332/modules/common/job/job.go#L94-L113) for more context.