### PR TITLE
Default `preserveJobs` to `true` and fix docs typo

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1509,6 +1509,9 @@ spec:
                 type: string
               preserveJobs:
                 default: true
+                enum:
+                - true
+                - false
                 type: boolean
               restartPolicy:
                 default: Never

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -73,10 +73,11 @@ type OpenStackAnsibleEESpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:OnFailure","urn:alm:descriptor:com.tectonic.ui:select:Never"}
 	// +kubebuilder:default:="Never"
 	RestartPolicy string `json:"restartPolicy,omitempty"`
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=true
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
-	PreserveJobs bool `json:"preserveJobs"`
+	// PreserveJobs default: true
+	// +kubebuilder:validation:Enum:=true;false
+	// +kubebuilder:default:=true
+	PreserveJobs bool `json:"preserveJobs,omitempty"`
 	// UID is the userid that will be used to run the container.
 	// +kubebuilder:default:=1001
 	UID int64 `json:"uid,omitempty"`
@@ -85,7 +86,7 @@ type OpenStackAnsibleEESpec struct {
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
 	ExtraMounts []storage.VolMounts `json:"extraMounts,omitempty"`
-	// BackoffLimimt allows to define the maximum number of retried executions (defaults to 6).
+	// BackoffLimit allows to define the maximum number of retried executions (defaults to 6).
 	// +kubebuilder:default:=6
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
@@ -217,7 +218,7 @@ func NewOpenStackAnsibleEE(name string) OpenStackAnsibleEESpec {
 		Name:             name,
 		Image:            util.GetEnvVar("ANSIBLEEE_IMAGE_URL_DEFAULT", OpenStackAnsibleEEContainerImage),
 		EnvConfigMapName: "openstack-aee-default-env",
-		PreserveJobs:     false,
+		PreserveJobs:     true,
 		RestartPolicy:    "Never",
 		UID:              1001,
 		BackoffLimit:     &backoff,

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1509,6 +1509,9 @@ spec:
                 type: string
               preserveJobs:
                 default: true
+                enum:
+                - true
+                - false
                 type: boolean
               restartPolicy:
                 default: Never

--- a/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
@@ -16,8 +16,8 @@ spec:
       kind: OpenStackAnsibleEE
       name: openstackansibleees.ansibleee.openstack.org
       specDescriptors:
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions (defaults to 6).
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 6).
         displayName: Backoff Limit
         path: backoffLimit
         x-descriptors:

--- a/docs/openstack_ansibleee.md
+++ b/docs/openstack_ansibleee.md
@@ -72,11 +72,11 @@ OpenStackAnsibleEESpec defines the desired state of OpenStackAnsibleEE
 | envConfigMapName | EnvConfigMapName is the name of the k8s config map that contains the ansible env variables | string | false |
 | env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
 | restartPolicy | RestartPolicy is the policy applied to the Job on whether it needs to restart the Pod. It can be \"OnFailure\" or \"Never\". RestartPolicy default: Never | string | false |
-| preserveJobs | PreserveJobs - do not delete jobs after they finished e.g. to check logs | bool | true |
+| preserveJobs | PreserveJobs - do not delete jobs after they finished e.g. to check logs PreserveJobs default: true | bool | false |
 | uid | UID is the userid that will be used to run the container. | int64 | false |
 | inventory | Inventory is the inventory that the ansible playbook will use to launch the job. | string | false |
 | extraMounts | ExtraMounts containing conf files and credentials | []storage.VolMounts | false |
-| backoffLimit | BackoffLimimt allows to define the maximum number of retried executions (defaults to 6). | *int32 | false |
+| backoffLimit | BackoffLimit allows to define the maximum number of retried executions (defaults to 6). | *int32 | false |
 | roles | Role is the description of an Ansible Role If both Play and Role are specified, Play takes precedence | *[Role](#role) | false |
 | networkAttachments | NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network | []string | false |
 | cmdLine | CmdLine is the command line passed to ansible-runner | string | false |


### PR DESCRIPTION
This patch is a follow up of https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/pull/179 which didn't work due to a typo.

* Fixed the typo in the `OpenStackAnsibleEESpec` struct
* Added kubebuilder field validation and marked field as not required
* Default to `true` in `NewOpenStackAnsibleEE` function
* Fixed typo in the description of `BackoffLimit` field

```
$ oc get osaee dataplane-deployment-repo-setup-edpm-compute -o json |jq '.spec.preserveJobs,.spec.ttlSecondsAfterFinished'
true
null
$ oc get jobs dataplane-deployment-repo-setup-edpm-compute
NAME                                           COMPLETIONS   DURATION   AGE
dataplane-deployment-repo-setup-edpm-compute   1/1           2m56s      15m
$ oc get pods -l openstackansibleee_cr=dataplane-deployment-repo-setup-edpm-compute
NAME                                                 READY   STATUS      RESTARTS   AGE
dataplane-deployment-repo-setup-edpm-compute-pz4xl   0/1     Completed   0          15m

```