### PR TITLE
Improved instructions on how to gather ansibleee related pods and fixed openstack-ansibleee-playbook-local playbook example

### DIFF
--- a/examples/openstack-ansibleee-playbook-local.yaml
+++ b/examples/openstack-ansibleee-playbook-local.yaml
@@ -4,10 +4,17 @@ metadata:
   name: ansibleee-playbook-local
   namespace: openstack
 spec:
-  playbook: "test.yaml"
-  # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
+  play: |
+    - name: Print hello world
+      hosts: all
+      tasks:
+      - name: Using debug statement
+        ansible.builtin.debug:
+          msg: "Hello, world! This is openstack-ansibleee-play.yaml"
   inventory: |
     all:
+      vars:
+        ansible_connection: local
       hosts:
         localhost
   env:


### PR DESCRIPTION
* Improved description of local playbook example
* Removed docker vs podman references
* Fixed `openstack-ansibleee-playbook-local.yaml` playbook
* Removed a link to an internal git repo
* Improved instructions on how to gather pods associated to proper `OpenStackAnsibleEE` resource.