### PR TITLE
Use central renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,42 +1,10 @@
 {
-"extends": [
-    "config:base"
+  "extends": [
+    "github>openstack-k8s-operators/renovate-config"
   ],
-  "dependencyDashboard": true,
-  "logFileLevel": "trace",
-  "enabledManagers": ["gomod"],
-  "postUpdateOptions": ["gomodTidy"],
   "constraints": {
     "go": "1.19"
   },
-  "schedule":[
-    "every weekend"
-  ],
-  "packageRules": [
-    {
-      "matchPackageNames": ["github.com/openstack-k8s-operators/openstack-ansibleee-operator/api"],
-      "enabled": false
-    },
-    {
-      "groupName": "openstack-k8s-operators",
-      "matchPackagePrefixes": ["github.com/openstack-k8s-operators"],
-      "excludePackageNames": ["github.com/openstack-k8s-operators/openstack-ansibleee-operator/api"],
-      "schedule": [
-        "every weekend"
-      ]
-    },
-    {
-      "groupName": "k8s.io",
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ],
-      "schedule": [
-        "every weekend"
-      ],
-      "allowedVersions": "< 1.0.0"
-    }
-  ],
   "postUpgradeTasks": {
     "commands": ["make gowork", "make tidy", "make manifests generate"],
     "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],


### PR DESCRIPTION
At the same time this change will pin the k8s and controller runtime dependencies for the dev preview

[1] https://github.com/openstack-k8s-operators/renovate-config