### PR TITLE
Preventing CLI command injection in a debug mode

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -299,6 +299,7 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(
 	// Override args list if we are in a debug mode
 	if instance.Spec.Debug {
 		args = []string{"sleep", "1d"}
+		r.Log.Info(fmt.Sprintf("Instance %s will be running in debug mode.", instance.Name))
 	}
 	podSpec := corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicy(instance.Spec.RestartPolicy),
@@ -354,7 +355,9 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(
 		// we need to ensure that Play and Role are empty before addPlaybook
 		addPlaybook(instance, h, job, hashes)
 	}
-	if len(instance.Spec.CmdLine) > 0 {
+	if len(instance.Spec.CmdLine) > 0 && !instance.Spec.Debug {
+		// RUNNER_CMDLINE environment variable should only be set
+		// if the operator isn't running in a debug mode.
 		addCmdLine(instance, h, job, hashes)
 	}
 	if len(labels["deployIdentifier"]) > 0 {

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
@@ -50,10 +50,11 @@ namespaced: true
 commands:
   - script: |
       pod=$(oc get pods -n openstack -l app=openstackansibleee,job-name=ansibleee-play-debug -o name)
-      description=$(oc describe -n openstack "$pod" | grep 'Hello, world this is ansibleee-play-debug.yaml')
+      description=$(oc describe -n openstack "$pod")
+      playbook_present=$(echo "$description" | grep 'Hello, world this is ansibleee-play-debug.yaml')
       echo Pod name: $pod
       echo Description: $description
-      if [ -n "$description" ]; then
+      if [ -n "$playbook_present" ]; then
         exit 0
       else
         exit 1

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
@@ -9,7 +9,7 @@
 apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
-  name: ansibleee-play
+  name: ansibleee-play-debug
   namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
@@ -20,44 +20,48 @@ spec:
       tasks:
       - name: Using debug statement
         ansible.builtin.debug:
-          msg: "Hello, world this is ansibleee-play.yaml"
+          msg: "Hello, world this is ansibleee-play-debug.yaml"
+  debug: true
 status:
-  JobStatus: Succeeded
+  JobStatus: Running
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  generateName: ansibleee-play-
-  labels:
-    app: openstackansibleee
-    job-name: ansibleee-play
+  generateName: ansibleee-play-debug-
   namespace: openstack
+  labels:
+    job-name: ansibleee-play-debug
 status:
-  phase: Succeeded
+  phase: Running
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
     app: openstackansibleee
-    job-name: ansibleee-play
-  name: ansibleee-play
+    job-name: ansibleee-play-debug
+  name: ansibleee-play-debug
   namespace: openstack
-status:
-  succeeded: 1
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      pod=$(oc get pods -n openstack -l app=openstackansibleee,job-name=ansibleee-play -o name)
+      pod=$(oc get pods -n openstack -l app=openstackansibleee,job-name=ansibleee-play-debug -o name)
       description=$(oc describe -n openstack "$pod")
-      logs=$(echo "$description" | grep 'Hello, world this is ansibleee-play.yaml')
+      playbook_present=$(echo "$description" | grep 'Hello, world this is ansibleee-play-debug.yaml')
+      cmdline_present=$(echo "$description" | grep 'Hello, world this is ansibleee-play-debug.yaml')
       echo Pod name: $pod
       echo Description: $description
-      if [ -n "$logs" ]; then
+      if [ -n "$playbook_present" ]; then
         exit 0
       else
         exit 1
+      fi
+      if [ -z "$cmdline_present" ]; then
+        exit 1
+      else
+        exit 0
       fi

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
@@ -1,0 +1,16 @@
+apiVersion: ansibleee.openstack.org/v1alpha1
+kind: OpenStackAnsibleEE
+metadata:
+  name: ansibleee-play-debug
+  namespace: openstack
+spec:
+  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+  play: |
+    - name: Print hello world
+      hosts: localhost
+      tasks:
+      - name: Using debug statement
+        ansible.builtin.debug:
+          msg: "Hello, world this is ansibleee-play-debug.yaml"
+  debug: true
+  cmdLine: "echo This shouldn't be printed."

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/02-cleanup.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/02-cleanup.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: ansibleee.openstack.org/v1alpha1
+  kind: OpenStackAnsibleEE
+  name: ansibleee-play-debug

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/02-errors.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/02-errors.yaml
@@ -1,0 +1,23 @@
+#
+# Check for:
+#
+# - No Ansibleee-play pod
+# - No Ansibleee-play job
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: ansible-play-
+  labels:
+    app: openstackansibleee-debug
+    job-name: ansibleee-play-debug
+  namespace: openstack
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: openstackansibleee-debug
+    job-name: ansibleee-play-debug
+  name: ansibleee-play-debug
+  namespace: openstack


### PR DESCRIPTION
Also sets up a log message announcing that the operator is running in a debug mode and expands the test coverage.

I did forget about an edge case that may cause problems down the line. I haven't seen any yet, but I would rather err on the side of caution here.