### PR TITLE
Update default tag

### DIFF
--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -28,7 +28,7 @@ const (
 	// Container image fall-back defaults
 
 	// OpenStackAnsibleEEContainerImage is the fall-back container image for OpenStackAnsibleEE
-	OpenStackAnsibleEEContainerImage = "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
+	OpenStackAnsibleEEContainerImage = "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:v0.1.0"
 )
 
 const (


### PR DESCRIPTION
I'm wondering if we should release https://github.com/openstack-k8s-operators/edpm-ansible v0.1.0 update the tag here and then release AEE v0.1.1