### PR TITLE
Change kuttl tests to run in any namespace

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,7 +1,7 @@
 #
 # EXECUTION (from install_yamls repo root):
 #
-#   make openstack_ansibleee_kuttl
+#   make ansibleee_kuttl
 #
 # ASSUMPTIONS:
 #
@@ -16,9 +16,9 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
+namespace: ansibleee-kuttl-tests
 reportFormat: JSON
 reportName: kuttl-test-openstack-ansibleee
-namespace: openstack
 timeout: 180
 parallel: 1
 suppress:

--- a/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
@@ -10,7 +10,6 @@ apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play
-  namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
@@ -31,7 +30,6 @@ metadata:
   labels:
     app: openstackansibleee
     job-name: ansibleee-play
-  namespace: openstack
 status:
   phase: Succeeded
 ---
@@ -42,17 +40,15 @@ metadata:
     app: openstackansibleee
     job-name: ansibleee-play
   name: ansibleee-play
-  namespace: openstack
 status:
   succeeded: 1
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
-      pod=$(oc get pods -n openstack -l app=openstackansibleee,job-name=ansibleee-play -o name)
-      description=$(oc describe -n openstack "$pod")
+      pod=$(oc get pods -n $NAMESPACE -l app=openstackansibleee,job-name=ansibleee-play -o name)
+      description=$(oc describe -n $NAMESPACE "$pod")
       logs=$(echo "$description" | grep 'Hello, world this is ansibleee-play.yaml')
       echo Pod name: $pod
       echo Description: $description

--- a/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
@@ -2,7 +2,6 @@ apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play
-  namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |

--- a/tests/kuttl/tests/run_simple_playbook/02-errors.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/02-errors.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app: openstackansibleee
     job-name: ansibleee-play
-  namespace: openstack
 ---
 apiVersion: batch/v1
 kind: Job
@@ -20,4 +19,3 @@ metadata:
     app: openstackansibleee
     job-name: ansibleee-play
   name: ansibleee-play
-  namespace: openstack

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
@@ -10,7 +10,6 @@ apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
-  namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
@@ -29,7 +28,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   generateName: ansibleee-play-debug-
-  namespace: openstack
   labels:
     job-name: ansibleee-play-debug
 status:
@@ -42,15 +40,13 @@ metadata:
     app: openstackansibleee
     job-name: ansibleee-play-debug
   name: ansibleee-play-debug
-  namespace: openstack
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
-      pod=$(oc get pods -n openstack -l app=openstackansibleee,job-name=ansibleee-play-debug -o name)
-      description=$(oc describe -n openstack "$pod")
+      pod=$(oc get pods -n $NAMESPACE -l app=openstackansibleee,job-name=ansibleee-play-debug -o name)
+      description=$(oc describe -n $NAMESPACE "$pod")
       playbook_present=$(echo "$description" | grep 'Hello, world this is ansibleee-play-debug.yaml')
       echo Pod name: $pod
       echo Description: $description

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
@@ -2,7 +2,6 @@ apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
-  namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |

--- a/tests/kuttl/tests/run_simple_playbook_debug/02-errors.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/02-errors.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app: openstackansibleee-debug
     job-name: ansibleee-play-debug
-  namespace: openstack
 ---
 apiVersion: batch/v1
 kind: Job
@@ -20,4 +19,3 @@ metadata:
     app: openstackansibleee-debug
     job-name: ansibleee-play-debug
   name: ansibleee-play-debug
-  namespace: openstack

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
@@ -10,7 +10,6 @@ apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
-  namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
@@ -29,7 +28,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   generateName: ansibleee-play-debug-
-  namespace: openstack
   labels:
     job-name: ansibleee-play-debug
 status:
@@ -42,15 +40,13 @@ metadata:
     app: openstackansibleee
     job-name: ansibleee-play-debug
   name: ansibleee-play-debug
-  namespace: openstack
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
-      pod=$(oc get pods -n openstack -l app=openstackansibleee,job-name=ansibleee-play-debug -o name)
-      description=$(oc describe -n openstack "$pod")
+      pod=$(oc get pods -n $NAMESPACE -l app=openstackansibleee,job-name=ansibleee-play-debug -o name)
+      description=$(oc describe -n $NAMESPACE "$pod")
       playbook_present=$(echo "$description" | grep 'Hello, world this is ansibleee-play-debug.yaml')
       cmdline_present=$(echo "$description" | grep 'Hello, world this is ansibleee-play-debug.yaml')
       echo Pod name: $pod

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
@@ -2,7 +2,6 @@ apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
-  namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/02-errors.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/02-errors.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app: openstackansibleee-debug
     job-name: ansibleee-play-debug
-  namespace: openstack
 ---
 apiVersion: batch/v1
 kind: Job
@@ -20,4 +19,3 @@ metadata:
     app: openstackansibleee-debug
     job-name: ansibleee-play-debug
   name: ansibleee-play-debug
-  namespace: openstack


### PR DESCRIPTION
Modify the kuttl tests so that they can run in any namespace, not just
in the openstack one. This requires removing any mention of the
namespace in the asserts and using the $NAMESPACE variable in scripts
instead of the namespace name.
