### PR TITLE
Expanding input hash to cover entire podSpec struct

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -365,6 +365,8 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(
 
 	addMounts(instance, job)
 
+	hashPodSpec(h, podSpec, hashes)
+
 	inputHash, errorHash := hashOfInputHashes(hashes)
 	if errorHash != nil {
 		return nil, fmt.Errorf("error generating hash of input hashes: %w", errorHash)
@@ -474,6 +476,20 @@ func addPlaybook(
 	hashes["playbooks"], err = calculateHash(playbook)
 	if err != nil {
 		h.GetLogger().Error(err, "Error calculating the hash")
+	}
+}
+
+func hashPodSpec(
+	h *helper.Helper,
+	podSpec corev1.PodSpec,
+	hashes map[string]string,
+) {
+	var err error
+	spec, _ := podSpec.Marshal()
+	hashes["podspec"], err = calculateHash(string(spec))
+
+	if err != nil {
+		h.GetLogger().Error(err, "Error calculating the PodSpec hash")
 	}
 }
 


### PR DESCRIPTION
The input hash now covers all elements of the podSpec, such as arguments, image, name and args.

Previously we have been running our tests with false negative results. We were triggering edge condition by modifying `args`, which indirectly modified our `playbook` attribute. However, unlike the `playbook`, the `args` didn't actually influence the hash in any way.

https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/blob/main/controllers/openstack_ansibleee_controller.go#L273C2-L279C3 
