### PR TITLE
Removing duplicated code from operator 

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -133,9 +133,7 @@ func (r *OpenStackAnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Initialize Status fields
-	if instance.Status.Hash == nil {
-		instance.Status.Hash = map[string]string{}
-	}
+	util.InitMap(&instance.Status.Hash)
 	if instance.Status.NetworkAttachments == nil {
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -278,17 +278,10 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(
 		args = []string{"ansible-runner", "run", "/runner", "-p", playbook}
 	}
 
-	hasIdentifier := false
-	for _, arg := range args {
-		// ansible runner identifier
-		// https://ansible-runner.readthedocs.io/en/stable/intro/#artifactdir
-		if arg == "-i" || arg == "--ident" {
-			hasIdentifier = true
-			break
-		}
-	}
-
-	if !hasIdentifier {
+	// ansible runner identifier
+	// if the flag is set we use resource name as an argument
+	// https://ansible-runner.readthedocs.io/en/stable/intro/#artifactdir
+	if !(util.StringInSlice("-i", args) || util.StringInSlice("--ident", args)) {
 		identifier := instance.Name
 		args = append(args, []string{"-i", identifier}...)
 	}


### PR DESCRIPTION
Most of these changes are fairly straightforward. Some utilities in lib-common already provide what we are using here, so there is no need for the extra implementation. The environment variables of containers were set by virtually identical functions. These were replaced with a single, general function, with exception of role processing, which parses the yaml file before handing it over to the new function. We'll probably remove the `addRoles` at a later date.