### PR TITLE
Do not overwrite the job error message

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -210,7 +210,6 @@ func (r *OpenStackAnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	if err != nil {
-		err = fmt.Errorf("job.name %s job.namespace %s failed", jobDef.Name, jobDef.Namespace)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			redhatcomv1alpha1.AnsibleExecutionJobReadyCondition,
 			condition.ErrorReason,

--- a/tests/functional/ansibleee_controller_test.go
+++ b/tests/functional/ansibleee_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package functional_test
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -103,10 +101,7 @@ var _ = Describe("Ansibleee controller", func() {
 					v1alpha1.AnsibleExecutionJobReadyCondition,
 					corev1.ConditionFalse,
 					condition.ErrorReason,
-					fmt.Sprintf(
-						"AnsibleExecutionJob error occured job.name %s job.namespace %s failed",
-						ansibleee.Name, ansibleeeName.Namespace,
-					),
+					"AnsibleExecutionJob error occured Internal error occurred: Job Failed. Check job logs",
 				)
 				th.ExpectCondition(
 					ansibleeeName,
@@ -299,10 +294,7 @@ var _ = Describe("Ansibleee controller", func() {
 					v1alpha1.AnsibleExecutionJobReadyCondition,
 					corev1.ConditionFalse,
 					condition.ErrorReason,
-					fmt.Sprintf(
-						"AnsibleExecutionJob error occured job.name %s job.namespace %s failed",
-						ansibleee.Name, ansibleeeName.Namespace,
-					),
+					"AnsibleExecutionJob error occured Internal error occurred: Job Failed. Check job logs",
 				)
 				th.ExpectCondition(
 					ansibleeeName,


### PR DESCRIPTION
Error message is handled by lib-common:
https://github.com/openstack-k8s-operators/lib-common/blob/main/modules/common/job/job.go