### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,70 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/openstack-ansibleee-operator.clusterserviceversion.yaml"
-
-echo "Creating ansibleee operator bundle"
+echo "Creating openstack-ansibleee operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/openstack-ansibleee-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-IMAGE_TAG_BASE=$(grep "^IMAGE_TAG_BASE" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-  digest_image=""
-  echo "CSV line: ${csv_image}"
-
-  # case where @ is in the csv_image image
-  if [[ "$csv_image" =~ .*"@".* ]]; then
-    delimeter='@'
-  else
-    delimeter=':'
-  fi
-
-  base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-  tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-  if [[ "$base_image:$tag_image" == "$IMAGE_TAG_BASE:latest" ]]; then
-    echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-    sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-  else
-    digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-    echo "Base image: $base_image"
-    if [ -n "$digest_image" ]; then
-      echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-      sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-    else
-      echo "$base_image${delimeter}$tag_image not changed"
-    fi
-  fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -177,7 +177,7 @@ func NewOpenStackAnsibleEE(name string) OpenStackAnsibleEESpec {
 	backoff := int32(6)
 	return OpenStackAnsibleEESpec{
 		Name:             name,
-		Image:            util.GetEnvVar("ANSIBLEEE_IMAGE_URL_DEFAULT", OpenStackAnsibleEEContainerImage),
+		Image:            util.GetEnvVar("RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", OpenStackAnsibleEEContainerImage),
 		EnvConfigMapName: "openstack-aee-default-env",
 		PreserveJobs:     true,
 		RestartPolicy:    "Never",
@@ -195,7 +195,7 @@ func (instance OpenStackAnsibleEE) IsReady() bool {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize OpenStackAnsibleEE defaults with them
 	openstackAnsibleEEDefaults := OpenStackAnsibleEEDefaults{
-		ContainerImageURL: util.GetEnvVar("ANSIBLEEE_IMAGE_URL_DEFAULT", OpenStackAnsibleEEContainerImage),
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", OpenStackAnsibleEEContainerImage),
 	}
 
 	SetupOpenStackAnsibleEEDefaults(openstackAnsibleEEDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,5 +11,5 @@ spec:
       containers:
       - name: manager
         env:
-        - name: ANSIBLEEE_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT
           value: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest

--- a/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: openstack-ansibleee-operator.v0.0.0
   namespace: placeholder
@@ -16,6 +17,47 @@ spec:
       displayName: OpenStack Ansible EE
       kind: OpenStackAnsibleEE
       name: openstackansibleees.ansibleee.openstack.org
+      version: ""
+    - description: OpenStackAnsibleEE is the Schema for the openstackansibleees API
+      displayName: OpenStack Ansible EE
+      kind: OpenStackAnsibleEE
+      name: openstackansibleees.ansibleee.openstack.org
+      specDescriptors:
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 6).
+        displayName: Backoff Limit
+        path: backoffLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: 'RestartPolicy is the policy applied to the Job on whether it
+          needs to restart the Pod. It can be "OnFailure" or "Never". RestartPolicy
+          default: Never'
+        displayName: Restart Policy
+        path: restartPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:OnFailure
+        - urn:alm:descriptor:com.tectonic.ui:select:Never
+      - description: any_errors_fatal defaults to true
+        displayName: Any Errors Fatal
+        path: roles.any_errors_fatal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: become defaults to false
+        displayName: Become
+        path: roles.become
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: gather_facts defaults to false
+        displayName: Gather Facts
+        path: roles.gather_facts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       version: v1alpha1
   description: The OpenStack Ansible Execution Environment Operator
   displayName: OpenStackAnsibleEE

--- a/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
@@ -11,7 +11,6 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play
 spec:
-  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   play: |
     - name: Print hello world
@@ -57,3 +56,31 @@ commands:
       else
         exit 1
       fi
+---
+# when using image digests the containerImage URLs are SHA's so we verify them with a script
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+      imageTuples=$(oc get -n openstack-operators deployment openstack-ansible-operator-controller-manager -o go-template="$tupleTemplate")
+      # format of imageTuple is: RELATED_IMAGE_ANSIBLEEE_<service>#<image URL with SHA> separated by newlines
+      for ITEM in $(echo $imageTuples); do
+        # it is an image
+        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+          NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_ANSIBLEEE_\([^_]*\)_.*|\1|')
+          IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+          template='{{.spec.image}}'
+          case $NAME in
+            API)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE openstackansibleee ansibleee-play -o go-template="$template")
+              ;;
+          esac
+          if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
+            echo "$NAME image does not equal $VALUE"
+            exit 1
+          fi
+        fi
+      done
+
+      exit 0

--- a/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
@@ -3,7 +3,6 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play
 spec:
-  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |
     - name: Print hello world
       hosts: localhost

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
@@ -11,7 +11,6 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
 spec:
-  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   play: |
     - name: Print hello world
@@ -55,3 +54,31 @@ commands:
       else
         exit 1
       fi
+---
+# when using image digests the containerImage URLs are SHA's so we verify them with a script
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+      imageTuples=$(oc get -n openstack-operators deployment openstack-ansible-operator-controller-manager -o go-template="$tupleTemplate")
+      # format of imageTuple is: RELATED_IMAGE_ANSIBLEEE_<service>#<image URL with SHA> separated by newlines
+      for ITEM in $(echo $imageTuples); do
+        # it is an image
+        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+          NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_ANSIBLEEE_\([^_]*\)_.*|\1|')
+          IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+          template='{{.spec.image}}'
+          case $NAME in
+            API)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE openstackansibleee ansibleee-play-debug -o go-template="$template")
+              ;;
+          esac
+          if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
+            echo "$NAME image does not equal $VALUE"
+            exit 1
+          fi
+        fi
+      done
+
+      exit 0

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
@@ -3,7 +3,6 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
 spec:
-  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |
     - name: Print hello world
       hosts: localhost

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
@@ -11,7 +11,6 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
 spec:
-  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   name: openstackansibleee
   play: |
     - name: Print hello world
@@ -61,3 +60,31 @@ commands:
       else
         exit 0
       fi
+---
+# when using image digests the containerImage URLs are SHA's so we verify them with a script
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+      imageTuples=$(oc get -n openstack-operators deployment openstack-ansible-operator-controller-manager -o go-template="$tupleTemplate")
+      # format of imageTuple is: RELATED_IMAGE_ANSIBLEEE_<service>#<image URL with SHA> separated by newlines
+      for ITEM in $(echo $imageTuples); do
+        # it is an image
+        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+          NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_ANSIBLEEE_\([^_]*\)_.*|\1|')
+          IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+          template='{{.spec.image}}'
+          case $NAME in
+            API)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE openstackansibleee ansibleee-play-debug -o go-template="$template")
+              ;;
+          esac
+          if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
+            echo "$NAME image does not equal $VALUE"
+            exit 1
+          fi
+        fi
+      done
+
+      exit 0

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
@@ -3,7 +3,6 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
 spec:
-  image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |
     - name: Print hello world
       hosts: localhost


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)

Jira: [OSP-26486](https://issues.redhat.com//browse/OSP-26486)