### PR TITLE
switch to structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ import (
 
 var (
 	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	setupLog = ctrl.Log.WithName("Setup").WithName("Controllers").WithName("OpenStackAnsibleEE")
 )
 
 func init() {
@@ -70,7 +70,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	devMode, err := strconv.ParseBool(os.Getenv("DEV_MODE"))
 	if err != nil {
-		devMode = false
+		devMode = true
 	}
 	opts := zap.Options{
 		Development: devMode,
@@ -115,7 +115,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackAnsibleEE"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackAnsibleEE")
 		os.Exit(1)

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -118,7 +118,6 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackAnsibleEE"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

`2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully`

after:

`2023-10-19T14:11:37+03:00       INFO    Controllers.OpenStackAnsibleEE  Job Status Active... requeuing  {"controller": "openstackansibleee", "controllerGroup": "ansibleee.openstack.org", "controllerKind": "OpenStackAnsibleEE", "OpenStackAnsibleEE": {"name":"openstackansibleee-sample","namespace":"openstack"}, "namespace": "openstack", "name": "openstackansibleee-sample", "reconcileID": "80a46468-d325-47ae-b426-99101aefedfa"}
`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.



