### PR TITLE
Switch the operator to use the multinode layout

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -27,8 +27,6 @@
       - renovate.json
 
 - job:
-    name: ansibleee-operator-crc-podified-edpm-deployment
-    parent: cifmw-crc-podified-edpm-deployment
-    vars:
-      bmo_setup: true
+    name: ansibleee-operator-podified-multinode-edpm-deployment-crc
+    parent: podified-multinode-edpm-deployment-crc
     irrelevant-files: *openstack_if

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,6 +4,6 @@
     github-check:
       jobs:
         - ansibleee-operator-content-provider
-        - ansibleee-operator-crc-podified-edpm-deployment:
+        - ansibleee-operator-podified-multinode-edpm-deployment-crc:
             dependencies:
               - ansibleee-operator-content-provider


### PR DESCRIPTION
Since we are getting rid off the nested EDPM jobs we are now changing the openstack-ansibleee-operator to use the multinode based EDPM deployment job.