### PR TITLE
Drop NewOpenStackAnsibleEE

### DIFF
--- a/api/v1alpha1/openstack_ansibleee_types.go
+++ b/api/v1alpha1/openstack_ansibleee_types.go
@@ -171,21 +171,6 @@ func init() {
 	SchemeBuilder.Register(&OpenStackAnsibleEE{}, &OpenStackAnsibleEEList{})
 }
 
-// NewOpenStackAnsibleEE returns a OpenStackAnsibleEESpec where the fields are defaulted according
-// to the CRD definition
-func NewOpenStackAnsibleEE(name string) OpenStackAnsibleEESpec {
-	backoff := int32(6)
-	return OpenStackAnsibleEESpec{
-		Name:             name,
-		Image:            util.GetEnvVar("RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", OpenStackAnsibleEEContainerImage),
-		EnvConfigMapName: "openstack-aee-default-env",
-		PreserveJobs:     true,
-		RestartPolicy:    "Never",
-		UID:              1001,
-		BackoffLimit:     &backoff,
-	}
-}
-
 // IsReady - returns true if the OpenStackAnsibleEE is ready
 func (instance OpenStackAnsibleEE) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(AnsibleExecutionJobReadyCondition)


### PR DESCRIPTION
This appears to be unused. Furthermore the required ENV var is likely to only be set via the AnsibleEEOperator's controller-manager process so it would be of limited use anyway.