### PR TITLE
Add workflow_dispatch even trigger for github workflows

### DIFF
--- a/.github/workflows/build-openstack-ansibleee-operator.yaml
+++ b/.github/workflows/build-openstack-ansibleee-operator.yaml
@@ -1,9 +1,10 @@
 name: OpenStackAnsibleEE Operator image builder
 
 on:
-  push:
-    branches:
-      - '*'
+  - push:
+      branches:
+        - '*'
+  - workflow_dispatch
 
 env:
   imageregistry: 'quay.io'

--- a/.github/workflows/release-openstack-ansibleee-operator.yaml
+++ b/.github/workflows/release-openstack-ansibleee-operator.yaml
@@ -1,10 +1,11 @@
 name: Release OpenStackAnsibleEE Operator
 
 on:
-  release:
-    types:
-      - released
-      - prereleased
+  - release:
+      types:
+        - released
+        - prereleased
+  - workflow_dispatch
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
In order to run these workflows manually from the GitHub UI, they need
to also be triggered by workflow_dispatch.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

They may need to be run manually at times in order to bump the version
of the openstack-ansibleee-runner image set in
$RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT by .github/create_bundle.sh.

Signed-off-by: James Slagle <jslagle@redhat.com>
