### PR TITLE
Fix github event trigger syntax

### DIFF
--- a/.github/workflows/build-openstack-ansibleee-operator.yaml
+++ b/.github/workflows/build-openstack-ansibleee-operator.yaml
@@ -1,10 +1,10 @@
 name: OpenStackAnsibleEE Operator image builder
 
 on:
-  - push:
-      branches:
-        - '*'
-  - workflow_dispatch
+  push:
+    branches:
+      - '*'
+  workflow_dispatch:
 
 env:
   imageregistry: 'quay.io'

--- a/.github/workflows/release-openstack-ansibleee-operator.yaml
+++ b/.github/workflows/release-openstack-ansibleee-operator.yaml
@@ -1,11 +1,11 @@
 name: Release OpenStackAnsibleEE Operator
 
 on:
-  - release:
-      types:
-        - released
-        - prereleased
-  - workflow_dispatch
+  release:
+    types:
+      - released
+      - prereleased
+  workflow_dispatch:
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
Apparently the GitHub docs are incorrect. "on" is not a list despite:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-multiple-events

as that fails:
https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/actions/runs/6580532153
with error:
Error: .github#L1
Invalid type for `on`

https://github.com/orgs/community/discussions/25595 seems to indicate
"on" is supposed to be a dict with multiple even triggers. This commit
tries that syntax.

Signed-off-by: James Slagle <jslagle@redhat.com>
