### PR TITLE
Change default runner version for dp2

### DIFF
--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     spec:
       containers:
-      - name: manager
-        env:
-        - name: RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT
-          value: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+        - name: manager
+          env:
+            - name: RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT
+              value: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:dev-preview2-latest


### PR DESCRIPTION
In `dev-preview2` branch, dataplane-operator and edpm-ansible should be tightly coupled to avoid issues.

Since we have tagged the dev-preview2 runner image with `dev-preview2-latest` tag, this patch will change the default image.

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/510