### PR TITLE
Use correct deployment name in kuttl tests

### DIFF
--- a/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
@@ -63,7 +63,7 @@ kind: TestAssert
 commands:
   - script: |
       tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
-      imageTuples=$(oc get -n openstack-operators deployment openstack-ansible-operator-controller-manager -o go-template="$tupleTemplate")
+      imageTuples=$(oc get -n openstack-operators deployment openstack-ansibleee-operator-controller-manager -o go-template="$tupleTemplate")
       # format of imageTuple is: RELATED_IMAGE_ANSIBLEEE_<service>#<image URL with SHA> separated by newlines
       for ITEM in $(echo $imageTuples); do
         # it is an image
@@ -72,12 +72,12 @@ commands:
           IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
           template='{{.spec.image}}'
           case $NAME in
-            API)
+            IMAGE)
               SERVICE_IMAGE=$(oc get -n $NAMESPACE openstackansibleee ansibleee-play -o go-template="$template")
               ;;
           esac
           if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
-            echo "$NAME image does not equal $VALUE"
+            echo "$SERVICE_IMAGE image does not equal $IMG_FROM_ENV"
             exit 1
           fi
         fi

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
@@ -61,7 +61,7 @@ kind: TestAssert
 commands:
   - script: |
       tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
-      imageTuples=$(oc get -n openstack-operators deployment openstack-ansible-operator-controller-manager -o go-template="$tupleTemplate")
+      imageTuples=$(oc get -n openstack-operators deployment openstack-ansibleee-operator-controller-manager -o go-template="$tupleTemplate")
       # format of imageTuple is: RELATED_IMAGE_ANSIBLEEE_<service>#<image URL with SHA> separated by newlines
       for ITEM in $(echo $imageTuples); do
         # it is an image
@@ -70,12 +70,12 @@ commands:
           IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
           template='{{.spec.image}}'
           case $NAME in
-            API)
+            IMAGE)
               SERVICE_IMAGE=$(oc get -n $NAMESPACE openstackansibleee ansibleee-play-debug -o go-template="$template")
               ;;
           esac
           if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
-            echo "$NAME image does not equal $VALUE"
+            echo "$SERVICE_IMAGE image does not equal $IMG_FROM_ENV"
             exit 1
           fi
         fi

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
@@ -67,7 +67,7 @@ kind: TestAssert
 commands:
   - script: |
       tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
-      imageTuples=$(oc get -n openstack-operators deployment openstack-ansible-operator-controller-manager -o go-template="$tupleTemplate")
+      imageTuples=$(oc get -n openstack-operators deployment openstack-ansibleee-operator-controller-manager -o go-template="$tupleTemplate")
       # format of imageTuple is: RELATED_IMAGE_ANSIBLEEE_<service>#<image URL with SHA> separated by newlines
       for ITEM in $(echo $imageTuples); do
         # it is an image
@@ -76,12 +76,12 @@ commands:
           IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
           template='{{.spec.image}}'
           case $NAME in
-            API)
+            IMAGE)
               SERVICE_IMAGE=$(oc get -n $NAMESPACE openstackansibleee ansibleee-play-debug -o go-template="$template")
               ;;
           esac
           if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
-            echo "$NAME image does not equal $VALUE"
+            echo "$SERVICE_IMAGE image does not equal $IMG_FROM_ENV"
             exit 1
           fi
         fi

--- a/tests/kuttl/tests/run_simple_playbook_extra_vars/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_extra_vars/01-assert.yaml
@@ -69,7 +69,7 @@ kind: TestAssert
 commands:
   - script: |
       tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
-      imageTuples=$(oc get -n openstack-operators deployment openstack-ansible-operator-controller-manager -o go-template="$tupleTemplate")
+      imageTuples=$(oc get -n openstack-operators deployment openstack-ansibleee-operator-controller-manager -o go-template="$tupleTemplate")
       # format of imageTuple is: RELATED_IMAGE_ANSIBLEEE_<service>#<image URL with SHA> separated by newlines
       for ITEM in $(echo $imageTuples); do
         # it is an image
@@ -78,12 +78,12 @@ commands:
           IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
           template='{{.spec.image}}'
           case $NAME in
-            API)
+            IMAGE)
               SERVICE_IMAGE=$(oc get -n $NAMESPACE openstackansibleee ansibleee-play-extravars -o go-template="$template")
               ;;
           esac
           if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
-            echo "$NAME image does not equal $VALUE"
+            echo "$SERVICE_IMAGE image does not equal $IMG_FROM_ENV"
             exit 1
           fi
         fi


### PR DESCRIPTION
Some assert files in the kuttl tests use an incorrect name when looking
for the controller-manager deployment. The check also apparently uses
some wrong variable name while grepping, so this is fixed here as well.
