### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -345,9 +345,9 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(ctx context.Cont
 		job.Spec.Template.Spec.ServiceAccountName = instance.Spec.ServiceAccountName
 	}
 	// Set primary inventory if specified as string
-	var existingInventoryMounts string = ""
+	existingInventoryMounts := ""
 	if len(instance.Spec.Inventory) > 0 {
-		setRunnerEnvVar(instance, h, "RUNNER_INVENTORY", instance.Spec.Inventory, "inventory", job, hashes)
+		setRunnerEnvVar(h, "RUNNER_INVENTORY", instance.Spec.Inventory, "inventory", job, hashes)
 		existingInventoryMounts = "/runner/inventory/inventory.yaml"
 	}
 	// Report additional inventory paths mounted as volumes
@@ -378,7 +378,7 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(ctx context.Cont
 				"error checking sanity of an inline play: %s %w",
 				instance.Spec.Play, valErr)
 		}
-		setRunnerEnvVar(instance, h, "RUNNER_PLAYBOOK", instance.Spec.Play, "play", job, hashes)
+		setRunnerEnvVar(h, "RUNNER_PLAYBOOK", instance.Spec.Play, "play", job, hashes)
 	} else if len(playbook) > 0 {
 		// As we set "playbook.yaml" as default
 		// we need to ensure that Play and Role are empty before addPlaybook
@@ -393,11 +393,11 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(ctx context.Cont
 			}
 		}
 
-		setRunnerEnvVar(instance, h, "RUNNER_PLAYBOOK", playbook, "playbooks", job, hashes)
+		setRunnerEnvVar(h, "RUNNER_PLAYBOOK", playbook, "playbooks", job, hashes)
 	}
 
 	if len(instance.Spec.CmdLine) > 0 {
-		setRunnerEnvVar(instance, h, "RUNNER_CMDLINE", instance.Spec.CmdLine, "cmdline", job, hashes)
+		setRunnerEnvVar(h, "RUNNER_CMDLINE", instance.Spec.CmdLine, "cmdline", job, hashes)
 	}
 	if len(labels["deployIdentifier"]) > 0 {
 		hashes["deployIdentifier"] = labels["deployIdentifier"]
@@ -417,7 +417,7 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(ctx context.Cont
 			}
 			parsedExtraVars += fmt.Sprintf("%s: %s\n", variable, tmp)
 		}
-		setRunnerEnvVar(instance, h, "RUNNER_EXTRA_VARS", parsedExtraVars, "extraVars", job, hashes)
+		setRunnerEnvVar(h, "RUNNER_EXTRA_VARS", parsedExtraVars, "extraVars", job, hashes)
 	}
 
 	hashPodSpec(h, podSpec, hashes)
@@ -496,7 +496,7 @@ func hashPodSpec(
 }
 
 // set value of runner environment variable and compute the hash
-func setRunnerEnvVar(instance *ansibleeev1.OpenStackAnsibleEE,
+func setRunnerEnvVar(
 	helper *helper.Helper,
 	varName string,
 	varValue string,

--- a/tests/functional/ansibleee_controller_test.go
+++ b/tests/functional/ansibleee_controller_test.go
@@ -21,9 +21,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	"github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1beta1"
 )

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package functional_test
 
 import (
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1beta1"

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+	"github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -60,7 +60,7 @@ var (
 	testEnv       *envtest.Environment
 	ctx           context.Context
 	cancel        context.CancelFunc
-	th            *TestHelper
+	th            *helpers.TestHelper
 	logger        logr.Logger
 	ansibleeeName types.NamespacedName
 )
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	th = NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	th = helpers.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 
 	// Start the controller-manager in a goroutine


### PR DESCRIPTION
This needed the following adjustments:
* ignore revive dot-imports rule on ginkgo and gomega as dot import
  there is the recommended practice
* removed unused parameters
* various small style fixes found by the linter
