### PR TITLE
Ensure job retries

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -407,11 +408,16 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(ctx context.Cont
 
 	// if we have any extra vars for ansible to use set them in the RUNNER_EXTRA_VARS
 	if len(instance.Spec.ExtraVars) > 0 {
+		keys := make([]string, 0, len(instance.Spec.ExtraVars))
+		for k := range instance.Spec.ExtraVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
 		parsedExtraVars := ""
 		// unmarshal nested data structures
-		for variable, val := range instance.Spec.ExtraVars {
+		for _, variable := range keys {
 			var tmp interface{}
-			err := yaml.Unmarshal(val, &tmp)
+			err := yaml.Unmarshal(instance.Spec.ExtraVars[variable], &tmp)
 			if err != nil {
 				return nil, err
 			}

--- a/tests/kuttl/tests/run_failed_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_failed_playbook/01-assert.yaml
@@ -1,0 +1,115 @@
+#
+# Check for:
+#
+# - 1 OpenStackAnsibleEE CR
+# - 1 failed-play pod
+# - 1 failed-play job
+# - Correct output from ansible play
+#
+apiVersion: ansibleee.openstack.org/v1beta1
+kind: OpenStackAnsibleEE
+metadata:
+  name: failed-play
+spec:
+  name: openstackansibleee
+  play: |
+    - name: Execution failure
+      hosts: localhost
+      tasks:
+      - name: Copy absent file
+        ansible.builtin.shell: |
+            set -euxo pipefail
+            cp absent failed_op
+  preserveJobs: true
+status:
+  JobStatus: Failed
+  conditions:
+  - message: 'AnsibleExecutionJob error occured Internal error occurred: Job Failed.
+      Check job logs'
+    reason: Error
+    severity: Warning
+    status: "False"
+    type: Ready
+  - message: 'AnsibleExecutionJob error occured Internal error occurred: Job Failed.
+      Check job logs'
+    reason: Error
+    severity: Warning
+    status: "False"
+    type: AnsibleExecutionJobReady
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: failed-play-
+  labels:
+    app: openstackansibleee
+    job-name: failed-play
+status:
+  phase: Failed
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: openstackansibleee
+    job-name: failed-play
+    openstackansibleee_cr: failed-play
+    osaee: "true"
+  name: failed-play
+spec:
+  backoffLimit: 3
+  completionMode: NonIndexed
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: openstackansibleee
+        batch.kubernetes.io/job-name: failed-play
+        job-name: failed-play
+        openstackansibleee_cr: failed-play
+        osaee: "true"
+    spec:
+      containers:
+      - args:
+        - ansible-runner
+        - run
+        - /runner
+        - -p
+        - playbook.yaml
+        - -i
+        - failed-play
+        env:
+        - name: RUNNER_PLAYBOOK
+          value: |2+
+
+            - name: Execution failure
+              hosts: localhost
+              tasks:
+              - name: Copy absent file
+                ansible.builtin.shell: |
+                    set -euxo pipefail
+                    cp absent failed_op
+
+
+        - name: RUNNER_EXTRA_VARS
+          value: |2+
+
+            aaa: %!s(int=1)
+            bbb: %!s(int=2)
+            ccc: %!s(int=3)
+
+
+        imagePullPolicy: Always
+        name: openstackansibleee
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - message: Job has reached the specified backoff limit
+    reason: BackoffLimitExceeded
+    status: "True"
+    type: Failed
+  failed: 4

--- a/tests/kuttl/tests/run_failed_playbook/01-run-absent-file.yaml
+++ b/tests/kuttl/tests/run_failed_playbook/01-run-absent-file.yaml
@@ -1,0 +1,18 @@
+apiVersion: ansibleee.openstack.org/v1beta1
+kind: OpenStackAnsibleEE
+metadata:
+  name: failed-play
+spec:
+  play: |
+    - name: Execution failure
+      hosts: localhost
+      tasks:
+      - name: Copy absent file
+        ansible.builtin.shell: |
+            set -euxo pipefail
+            cp absent failed_op
+  extraVars:
+    aaa: 1
+    ccc: 3
+    bbb: 2
+  backoffLimit: 3


### PR DESCRIPTION
When the keys are unordered, we get different hashes for the podSpec (which deletes the job: https://github.com/openstack-k8s-operators/lib-common/blob/main/modules/common/job/job.go#L260-L264)

