### PR TITLE
Propagate AEE annotations

### DIFF
--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -275,6 +275,11 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(ctx context.Cont
 	annotations map[string]string) (*batchv1.Job, error) {
 	Log := r.GetLogger(ctx)
 	labels := instance.GetObjectMeta().GetLabels()
+	instanceAnnotations := instance.GetObjectMeta().GetAnnotations()
+
+	for key, val := range instanceAnnotations {
+		annotations[key] = val
+	}
 
 	ls := labelsForOpenStackAnsibleEE(instance.Name, labels)
 


### PR DESCRIPTION
Related to: https://github.com/openstack-k8s-operators/dataplane-operator/pull/829
it will help to trace which nodeset inventory was applied to the jobs/pods