### PR TITLE
Make AEE containers resources configurable

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1530,6 +1530,37 @@ spec:
                 - true
                 - false
                 type: boolean
+              resources:
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                type: object
               restartPolicy:
                 default: Never
                 enum:

--- a/api/v1beta1/openstack_ansibleee_types.go
+++ b/api/v1beta1/openstack_ansibleee_types.go
@@ -101,6 +101,10 @@ type OpenStackAnsibleEESpec struct {
 	// +kubebuilder:validation:Optional
 	// InitContainers allows the passing of an array of containers that will be executed before the ansibleee execution itself
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
+	// Compute Resources required by this ansibleee job.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+	// +kubebuilder:validation:Optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// +kubebuilder:validation:Optional
 	// ServiceAccountName allows to specify what ServiceAccountName do we want the ansible execution run with. Without specifying,
 	// it will run with default serviceaccount

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -157,6 +157,7 @@ func (in *OpenStackAnsibleEESpec) DeepCopyInto(out *OpenStackAnsibleEESpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	if in.DNSConfig != nil {
 		in, out := &in.DNSConfig, &out.DNSConfig
 		*out = new(v1.PodDNSConfig)

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1530,6 +1530,37 @@ spec:
                 - true
                 - false
                 type: boolean
+              resources:
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                type: object
               restartPolicy:
                 default: Never
                 enum:

--- a/controllers/openstack_ansibleee_controller.go
+++ b/controllers/openstack_ansibleee_controller.go
@@ -304,6 +304,7 @@ func (r *OpenStackAnsibleEEReconciler) jobForOpenStackAnsibleEE(ctx context.Cont
 			Name:            instance.Spec.Name,
 			Args:            args,
 			Env:             instance.Spec.Env,
+			Resources:       instance.Spec.Resources,
 		}},
 	}
 

--- a/docs/assemblies/openstack_ansibleee.adoc
+++ b/docs/assemblies/openstack_ansibleee.adoc
@@ -167,6 +167,11 @@ OpenStackAnsibleEESpec defines the desired state of OpenStackAnsibleEE
 | []corev1.Container
 | false
 
+| resources
+| Compute Resources required by this ansibleee job. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| corev1.ResourceRequirements
+| false
+
 | serviceAccountName
 | ServiceAccountName allows to specify what ServiceAccountName do we want the ansible execution run with. Without specifying, it will run with default serviceaccount
 | string


### PR DESCRIPTION
"Creating a pod without CPU requests or limits will effectively allow it to be scheduled on any suitable node, regardless of the amount of CPU left on that node. In practice, it will still get some minimal CPU guarantees. However, it will not be able to use much CPU time when there is node pressure"

https://www.datadoghq.com/blog/kubernetes-cpu-requests-limits/