### PR TITLE
Don't require in-line play text to start with list

### DIFF
--- a/api/v1beta1/openstackansibleee_webhook.go
+++ b/api/v1beta1/openstackansibleee_webhook.go
@@ -145,7 +145,6 @@ func (spec *OpenStackAnsibleEESpec) ValidateCreate() field.ErrorList {
 				))
 			}
 		}
-
 	}
 
 	for _, value := range spec.Env {
@@ -180,7 +179,7 @@ func (r *OpenStackAnsibleEE) ValidateDelete() (admission.Warnings, error) {
 // isPlay checks if the free form document has attributes of ansible play
 // Specifically if it is a parsable yaml with list as a root element
 func isPlay(document validator.FieldLevel) bool {
-	var play []map[string]interface{}
+	var play map[string]interface{}
 	err := yaml.Unmarshal([]byte(document.Field().String()), &play)
 	return err == nil
 }

--- a/examples/openstack-ansibleee-play-runner-extra-vars.yaml
+++ b/examples/openstack-ansibleee-play-runner-extra-vars.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: all
       tasks:
       - name: Using debug statement

--- a/examples/openstack-ansibleee-play.yaml
+++ b/examples/openstack-ansibleee-play.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: all
       tasks:
       - name: Using debug statement

--- a/examples/openstack-ansibleee-playbook-local.yaml
+++ b/examples/openstack-ansibleee-playbook-local.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: all
       tasks:
       - name: Using debug statement

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -28,7 +28,7 @@ import (
 const (
 	// This constant must NOT use tabs, as it as raw string passed to the ansible-runner
 	play = `
-- name: Print hello world
+  name: Print hello world
   hosts: all
   tasks:
     - name: Using debug statement
@@ -77,8 +77,8 @@ func CreateAnsibleee(name types.NamespacedName) client.Object {
 
 func CreateAnsibleeeWithParams(
 	name types.NamespacedName, playbook string, image string, play string,
-	cmdline string, extraVars map[string]interface{}, extraMounts []map[string]interface{}) client.Object {
-
+	cmdline string, extraVars map[string]interface{}, extraMounts []map[string]interface{},
+) client.Object {
 	raw := map[string]interface{}{
 		"apiVersion": "ansibleee.openstack.org/v1beta1",
 		"kind":       "OpenStackAnsibleEE",

--- a/tests/kuttl/tests/run_failed_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_failed_playbook/01-assert.yaml
@@ -13,13 +13,13 @@ metadata:
 spec:
   name: openstackansibleee
   play: |
-    - name: Execution failure
-      hosts: localhost
-      tasks:
-      - name: Copy absent file
-        ansible.builtin.shell: |
-            set -euxo pipefail
-            cp absent failed_op
+    name: Execution failure
+    hosts: localhost
+    tasks:
+    - name: Copy absent file
+      ansible.builtin.shell: |
+        set -euxo pipefail
+        cp absent failed_op
   preserveJobs: true
 status:
   JobStatus: Failed
@@ -83,13 +83,13 @@ spec:
         - name: RUNNER_PLAYBOOK
           value: |2+
 
-            - name: Execution failure
-              hosts: localhost
-              tasks:
-              - name: Copy absent file
-                ansible.builtin.shell: |
-                    set -euxo pipefail
-                    cp absent failed_op
+            name: Execution failure
+            hosts: localhost
+            tasks:
+            - name: Copy absent file
+              ansible.builtin.shell: |
+                set -euxo pipefail
+                cp absent failed_op
 
 
         - name: RUNNER_EXTRA_VARS

--- a/tests/kuttl/tests/run_failed_playbook/01-run-absent-file.yaml
+++ b/tests/kuttl/tests/run_failed_playbook/01-run-absent-file.yaml
@@ -4,13 +4,13 @@ metadata:
   name: failed-play
 spec:
   play: |
-    - name: Execution failure
-      hosts: localhost
-      tasks:
-      - name: Copy absent file
-        ansible.builtin.shell: |
-            set -euxo pipefail
-            cp absent failed_op
+    name: Execution failure
+    hosts: localhost
+    tasks:
+    - name: Copy absent file
+      ansible.builtin.shell: |
+        set -euxo pipefail
+        cp absent failed_op
   extraVars:
     aaa: 1
     ccc: 3

--- a/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   name: openstackansibleee
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement

--- a/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansibleee-play
 spec:
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   name: openstackansibleee
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansibleee-play-debug
 spec:
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-assert.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   name: openstackansibleee
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement

--- a/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug_cmdline/01-run-debug.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansibleee-play-debug
 spec:
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement

--- a/tests/kuttl/tests/run_simple_playbook_extra_vars/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_extra_vars/01-assert.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   name: openstackansibleee
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement

--- a/tests/kuttl/tests/run_simple_playbook_extra_vars/01-run-extra-vars.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_extra_vars/01-run-extra-vars.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansibleee-play-extravars
 spec:
   play: |
-    - name: Print hello world
+      name: Print hello world
       hosts: localhost
       tasks:
       - name: Using debug statement


### PR DESCRIPTION
This change removes the webhook validation requirement that in-line plays need to be lists. A play in Ansible is a dict, while a playbook is a list of plays. This change ensures we validate on the play format to conform with the terminology in use. For reference, see: https://github.com/ansible/ansible/blob/devel/test/units/playbook/test_play.py\#L48

Given the terminology we use in the OpenStackDataPlaneService of 'play', we should then validate on the Ansible defined 'play' format, rather than a 'playbook' format.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/835