### PR TITLE
Use play vs playbook terminology correctly

### DIFF
--- a/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/api/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1520,9 +1520,9 @@ spec:
                 items:
                   type: string
                 type: array
-              play:
-                type: string
               playbook:
+                type: string
+              playbookContents:
                 type: string
               preserveJobs:
                 default: true

--- a/api/v1beta1/openstack_ansibleee_types.go
+++ b/api/v1beta1/openstack_ansibleee_types.go
@@ -52,8 +52,8 @@ type OpenStackAnsibleEESpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Play is an inline playbook contents that ansible will run on execution.
-	Play string `json:"play,omitempty"`
+	// PlaybookContents is an inline playbook contents that ansible will run on execution.
+	PlaybookContents string `json:"playbookContents,omitempty"`
 	// Playbook is the playbook that ansible will run on this execution, accepts path or FQN from collection
 	Playbook string `json:"playbook,omitempty"`
 	// Image is the container image that will execute the ansible command

--- a/api/v1beta1/openstackansibleee_webhook.go
+++ b/api/v1beta1/openstackansibleee_webhook.go
@@ -105,7 +105,7 @@ func (spec *OpenStackAnsibleEESpec) ValidateCreate() field.ErrorList {
 	// Setting up input validation, including custom validators
 	validate := validator.New()
 	var errors field.ErrorList
-	if valErr := validate.RegisterValidation("play", isPlay); valErr != nil {
+	if valErr := validate.RegisterValidation("play", isPlaybook); valErr != nil {
 		errors = append(errors,
 			field.InternalError(
 				field.NewPath("spec"),
@@ -145,7 +145,6 @@ func (spec *OpenStackAnsibleEESpec) ValidateCreate() field.ErrorList {
 				))
 			}
 		}
-
 	}
 
 	for _, value := range spec.Env {
@@ -177,11 +176,11 @@ func (r *OpenStackAnsibleEE) ValidateDelete() (admission.Warnings, error) {
 	return nil, nil
 }
 
-// isPlay checks if the free form document has attributes of ansible play
+// isPlaybook checks if the free form document has attributes of ansible playbook
 // Specifically if it is a parsable yaml with list as a root element
-func isPlay(document validator.FieldLevel) bool {
-	var play []map[string]interface{}
-	err := yaml.Unmarshal([]byte(document.Field().String()), &play)
+func isPlaybook(document validator.FieldLevel) bool {
+	var playbook []map[string]interface{}
+	err := yaml.Unmarshal([]byte(document.Field().String()), &playbook)
 	return err == nil
 }
 

--- a/api/v1beta1/openstackansibleee_webhook.go
+++ b/api/v1beta1/openstackansibleee_webhook.go
@@ -105,7 +105,7 @@ func (spec *OpenStackAnsibleEESpec) ValidateCreate() field.ErrorList {
 	// Setting up input validation, including custom validators
 	validate := validator.New()
 	var errors field.ErrorList
-	if valErr := validate.RegisterValidation("play", isPlaybook); valErr != nil {
+	if valErr := validate.RegisterValidation("playbookContents", isPlaybook); valErr != nil {
 		errors = append(errors,
 			field.InternalError(
 				field.NewPath("spec"),
@@ -117,15 +117,15 @@ func (spec *OpenStackAnsibleEESpec) ValidateCreate() field.ErrorList {
 				field.NewPath("spec"),
 				fmt.Errorf("error registering input validation")))
 	}
-	if len(spec.Play) > 0 {
-		valErr := validate.Var(spec.Play, "play")
+	if len(spec.PlaybookContents) > 0 {
+		valErr := validate.Var(spec.PlaybookContents, "playbookContents")
 		if valErr != nil {
 			errors = append(errors, field.Invalid(
-				field.NewPath("spec.play"),
-				spec.Play,
+				field.NewPath("spec.playbookContents"),
+				spec.PlaybookContents,
 				fmt.Sprintf(
-					"error checking sanity of an inline play: %s %s",
-					spec.Play, valErr),
+					"error checking sanity of an inline playbook: %s %s",
+					spec.PlaybookContents, valErr),
 			))
 		}
 	} else if len(spec.Playbook) > 0 {

--- a/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
+++ b/config/crd/bases/ansibleee.openstack.org_openstackansibleees.yaml
@@ -1520,9 +1520,9 @@ spec:
                 items:
                   type: string
                 type: array
-              play:
-                type: string
               playbook:
+                type: string
+              playbookContents:
                 type: string
               preserveJobs:
                 default: true

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -1481,7 +1481,7 @@ spec:
                 items:
                   type: string
                 type: array
-              play:
+              playbookContents:
                 type: string
               playbook:
                 type: string

--- a/docs/assemblies/openstack_ansibleee.adoc
+++ b/docs/assemblies/openstack_ansibleee.adoc
@@ -87,8 +87,8 @@ OpenStackAnsibleEESpec defines the desired state of OpenStackAnsibleEE
 |===
 | Field | Description | Scheme | Required
 
-| play
-| Play is an inline playbook contents that ansible will run on execution.
+| playbookContents
+| PlaybookContents is an inline playbook contents that ansible will run on execution.
 | string
 | false
 

--- a/examples/openstack-ansibleee-play-runner-extra-vars.yaml
+++ b/examples/openstack-ansibleee-play-runner-extra-vars.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: all
       tasks:

--- a/examples/openstack-ansibleee-play.yaml
+++ b/examples/openstack-ansibleee-play.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   image: quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: all
       tasks:

--- a/examples/openstack-ansibleee-playbook-local.yaml
+++ b/examples/openstack-ansibleee-playbook-local.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansibleee-playbook-local
   namespace: openstack
 spec:
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: all
       tasks:

--- a/tests/functional/ansibleee_controller_test.go
+++ b/tests/functional/ansibleee_controller_test.go
@@ -187,10 +187,10 @@ var _ = Describe("Ansibleee controller", func() {
 
 		})
 
-		Context("with an inline play", func() {
+		Context("with an inline playbook", func() {
 			BeforeEach(func() {
 				DeferCleanup(th.DeleteInstance, CreateAnsibleeeWithParams(
-					ansibleeeName, "", "test-image", play, "", map[string]interface{}{}, []map[string]interface{}{}))
+					ansibleeeName, "", "test-image", playbookContents, "", map[string]interface{}{}, []map[string]interface{}{}))
 			})
 			It("runs a job and reports when it succeeds", func() {
 				th.ExpectConditionWithDetails(
@@ -321,7 +321,7 @@ var _ = Describe("Ansibleee controller", func() {
 					},
 				}
 				DeferCleanup(th.DeleteInstance, CreateAnsibleeeWithParams(
-					ansibleeeName, "", "test-image", play, "", map[string]interface{}{}, extraMounts))
+					ansibleeeName, "", "test-image", playbookContents, "", map[string]interface{}{}, extraMounts))
 			})
 			It("runs a job and reports when it succeeds", func() {
 				th.ExpectConditionWithDetails(
@@ -469,7 +469,7 @@ var _ = Describe("Ansibleee controller", func() {
 					},
 				}
 				DeferCleanup(th.DeleteInstance, CreateAnsibleeeWithParams(
-					ansibleeeName, "", "test-image", play, "", map[string]interface{}{}, extraMounts))
+					ansibleeeName, "", "test-image", playbookContents, "", map[string]interface{}{}, extraMounts))
 			})
 			It("runs a job and reports when it succeeds", func() {
 				th.ExpectConditionWithDetails(

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// This constant must NOT use tabs, as it as raw string passed to the ansible-runner
-	play = `
+	playbookContents = `
 - name: Print hello world
   hosts: all
   tasks:
@@ -36,7 +36,7 @@ const (
         msg: "Hello, world this is ansibleee-play.yaml"`
 
 	// This constant is meant to represent malformed inline play
-	malformedPlay = `
+	malformedPlaybook = `
 	- name: Print hello world
 	  hosts: all
 	  tasks:
@@ -76,7 +76,7 @@ func CreateAnsibleee(name types.NamespacedName) client.Object {
 }
 
 func CreateAnsibleeeWithParams(
-	name types.NamespacedName, playbook string, image string, play string,
+	name types.NamespacedName, playbook string, image string, playbookContents string,
 	cmdline string, extraVars map[string]interface{}, extraMounts []map[string]interface{}) client.Object {
 
 	raw := map[string]interface{}{
@@ -89,12 +89,12 @@ func CreateAnsibleeeWithParams(
 		"spec": map[string]interface{}{
 			// this can be removed as soon as webhook is enabled in the
 			// test env
-			"image":       image,
-			"playbook":    playbook,
-			"play":        play,
-			"cmdline":     cmdline,
-			"extraVars":   extraVars,
-			"extraMounts": extraMounts,
+			"image":            image,
+			"playbook":         playbook,
+			"playbookContents": playbookContents,
+			"cmdline":          cmdline,
+			"extraVars":        extraVars,
+			"extraMounts":      extraMounts,
 		},
 	}
 

--- a/tests/functional/openstackansibleee_webhook_test.go
+++ b/tests/functional/openstackansibleee_webhook_test.go
@@ -31,13 +31,13 @@ var _ = Describe("OpenStackAnsibleEE Webhook", func() {
 				[]map[string]interface{}{}))
 		})
 	})
-	When("User creates ansibleee resource with a valid inline play", func() {
+	When("User creates ansibleee resource with a valid inline playbook", func() {
 		It("should be accepted", func() {
 			DeferCleanup(th.DeleteInstance, CreateAnsibleeeWithParams(
 				ansibleeeName,
 				"",
 				"test-image",
-				play,
+				playbookContents,
 				"",
 				map[string]interface{}{},
 				[]map[string]interface{}{},
@@ -85,10 +85,10 @@ var _ = Describe("OpenStackAnsibleEE Webhook", func() {
 						"spec": map[string]interface{}{
 							// this can be removed as soon as webhook is enabled in the
 							// test env
-							"image":    "test-image",
-							"playbook": "",
-							"play":     malformedPlay,
-							"cmdline":  "",
+							"image":            "test-image",
+							"playbook":         "",
+							"playbookContents": malformedPlaybook,
+							"cmdline":          "",
 						},
 					}
 					unstructuredObj := &unstructured.Unstructured{Object: newInstance}

--- a/tests/kuttl/tests/run_failed_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_failed_playbook/01-assert.yaml
@@ -12,7 +12,7 @@ metadata:
   name: failed-play
 spec:
   name: openstackansibleee
-  play: |
+  playbookContents: |
     - name: Execution failure
       hosts: localhost
       tasks:

--- a/tests/kuttl/tests/run_failed_playbook/01-run-absent-file.yaml
+++ b/tests/kuttl/tests/run_failed_playbook/01-run-absent-file.yaml
@@ -3,7 +3,7 @@ kind: OpenStackAnsibleEE
 metadata:
   name: failed-play
 spec:
-  play: |
+  playbookContents: |
     - name: Execution failure
       hosts: localhost
       tasks:

--- a/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-assert.yaml
@@ -12,7 +12,7 @@ metadata:
   name: ansibleee-play
 spec:
   name: openstackansibleee
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: localhost
       tasks:

--- a/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
+++ b/tests/kuttl/tests/run_simple_playbook/01-run-hello-world.yaml
@@ -3,7 +3,7 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play
 spec:
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: localhost
       tasks:

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-assert.yaml
@@ -12,7 +12,7 @@ metadata:
   name: ansibleee-play-debug
 spec:
   name: openstackansibleee
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: localhost
       tasks:

--- a/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_debug/01-run-debug.yaml
@@ -3,7 +3,7 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-debug
 spec:
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: localhost
       tasks:

--- a/tests/kuttl/tests/run_simple_playbook_extra_vars/01-assert.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_extra_vars/01-assert.yaml
@@ -12,7 +12,7 @@ metadata:
   name: ansibleee-play-extravars
 spec:
   name: openstackansibleee
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: localhost
       tasks:

--- a/tests/kuttl/tests/run_simple_playbook_extra_vars/01-run-extra-vars.yaml
+++ b/tests/kuttl/tests/run_simple_playbook_extra_vars/01-run-extra-vars.yaml
@@ -3,7 +3,7 @@ kind: OpenStackAnsibleEE
 metadata:
   name: ansibleee-play-extravars
 spec:
-  play: |
+  playbookContents: |
     - name: Print hello world
       hosts: localhost
       tasks:


### PR DESCRIPTION
An Ansible Play is not the same as an Ansible Playbook. This change corrects some of the terminology and makes openstack-ansibleee-operator consistent with the dataplane-operator

