### PR TITLE
Removed deprecated and unneeded annotations

### DIFF
--- a/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-ansibleee-operator.clusterserviceversion.yaml
@@ -11,8 +11,6 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operatorframework.io/suggested-namespace: openstack
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: openstack-ansibleee-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
Since version OCP version 4.14 the annotation `operators.openshift.io/infrastructure-features` was removed replaced by `features.operators.openshift.io/disconnected` already added in #384

Also, drops the suggested namespace annotation which is not needed.

Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>