### PR TITLE
[make][pre-commit]Check CRD schema to avoid update issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
       entry: make
       args: ['docs']
       pass_filenames: false
+    - id: make-crd-schema-check
+      name: make-crd-schema-check
+      language: system
+      entry: make
+      args: ['crd-schema-check']
+      pass_filenames: false
 
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1

--- a/Makefile
+++ b/Makefile
@@ -429,3 +429,12 @@ run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
 $(GINKGO): $(LOCALBIN)
 	test -s $(LOCALBIN)/ginkgo || GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo
+
+CRD_SCHEMA_CHECKER_VERSION ?= release-4.16
+
+BRANCH=main
+
+PHONY: crd-schema-check
+crd-schema-check: manifests
+	INSTALL_DIR=$(LOCALBIN) CRD_SCHEMA_CHECKER_VERSION=$(CRD_SCHEMA_CHECKER_VERSION) hack/build-crd-schema-checker.sh
+	INSTALL_DIR=$(LOCALBIN) BASE_REF="$${PULL_BASE_SHA:-$(BRANCH)}" hack/crd-schema-checker.sh

--- a/hack/build-crd-schema-checker.sh
+++ b/hack/build-crd-schema-checker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ -f "$INSTALL_DIR/crd-schema-checker" ]; then
+    exit 0
+fi
+
+mkdir -p "$INSTALL_DIR/git-tmp"
+git clone https://github.com/openshift/crd-schema-checker.git \
+    -b "$CRD_SCHEMA_CHECKER_VERSION" "$INSTALL_DIR/git-tmp"
+pushd "$INSTALL_DIR/git-tmp"
+GOWORK=off make
+cp crd-schema-checker "$INSTALL_DIR/"
+popd
+rm -rf "$INSTALL_DIR/git-tmp"

--- a/hack/crd-schema-checker.sh
+++ b/hack/crd-schema-checker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euxo pipefail
+
+CHECKER=$INSTALL_DIR/crd-schema-checker
+
+TMP_DIR=$(mktemp -d)
+
+function cleanup {
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+
+for crd in config/crd/bases/*.yaml; do
+    mkdir -p "$(dirname "$TMP_DIR/$crd")"
+    git show "$BASE_REF:$crd" > "$TMP_DIR/$crd"
+    $CHECKER check-manifests \
+        --existing-crd-filename="$TMP_DIR/$crd" \
+        --new-crd-filename="$crd"
+done


### PR DESCRIPTION
The new crd-schema-check make target compares the CRD schema of the patch with the schema on the tip of main and report errors on non backward compatible changes.

This make target now also run in pre-commit both locally and in CI.

This make target uses https://github.com/openshift/crd-schema-checker to do the actual checking.

Related: [OSPRH-11833](https://issues.redhat.com//browse/OSPRH-11833)